### PR TITLE
Windows progress bar

### DIFF
--- a/pb_win.go
+++ b/pb_win.go
@@ -14,5 +14,8 @@ func bold(str string) string {
 
 func terminalWidth() (int, error) {
 	screenBufInfo := w32.GetConsoleScreenBufferInfo(w32.HANDLE(syscall.Stdout))
-	return int(screenBufInfo.DwSize.X)-1, nil
+	if screenBufInfo == nil {
+		return 79, nil
+	}
+	return int(screenBufInfo.DwSize.X) - 1, nil
 }


### PR DESCRIPTION
I found a library that wraps Windows system calls in Go. This allowed me to get the terminal width for the progress bar.
