### PR TITLE
Fix ProgressBar struct alignment error

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -47,6 +47,8 @@ func StartNew(total int) (pb *ProgressBar) {
 type Callback func(out string)
 
 type ProgressBar struct {
+	current int64 // current must be first member of struct (https://code.google.com/p/go/issues/detail?id=5278)
+
 	Total                            int64
 	RefreshRate                      time.Duration
 	ShowPercent, ShowCounters        bool
@@ -56,7 +58,6 @@ type ProgressBar struct {
 	NotPrint                         bool
 	Units                            int
 
-	current   int64
 	isFinish  bool
 	startTime time.Time
 }


### PR DESCRIPTION
`current` must be first member of ProgressBar struct otherwise `c = atomic.LoadInt64(&pb.current)` might panic on i686 and ARM.

See https://code.google.com/p/go/issues/detail?id=5278 and http://golang.org/src/pkg/sync/atomic/doc.go#L48
