### PR TITLE
Fixing hidden pb when current progress is 0

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -199,6 +199,7 @@ func (pb *ProgressBar) write(current int64) {
 
 func (pb *ProgressBar) writer() {
 	var c, oc int64
+	oc = -1
 	for {
 		if pb.isFinish {
 			break


### PR DESCRIPTION
pb never prints the progress bar until the first task is completed.
