### PR TITLE
added carriage return to writer output

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -240,7 +240,7 @@ func (pb *ProgressBar) write(current int64) {
 	// and print!
 	switch {
 	case pb.Output != nil:
-		fmt.Fprint(pb.Output, out+end)
+		fmt.Fprint(pb.Output, "\r"+out+end)
 	case pb.Callback != nil:
 		pb.Callback(out + end)
 	case !pb.NotPrint:


### PR DESCRIPTION
I'm sure there was a reason for this, but I've been writing the bar to /dev/stderr and needed the carriage return. Did not see another way to do it and wasn't sure that it could be accomplished using the MultiWriter(). Not sure if issue or intentionally left out.
