### PR TITLE
Added an ability to create int64 counter

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -25,8 +25,13 @@ var (
 
 // Create new progress bar object
 func New(total int) (pb *ProgressBar) {
+	return New64(int64(total))
+}
+
+// Create new progress bar object uding int64 as total
+func New64(total int64) (pb *ProgressBar) {
 	pb = &ProgressBar{
-		Total:        int64(total),
+		Total:        total,
 		RefreshRate:  DEFAULT_REFRESH_RATE,
 		ShowPercent:  true,
 		ShowCounters: true,


### PR DESCRIPTION
While progress bar counter is operating with int64 there is no convenient constructor to init progress bar with an int64 total.

Added an alternative New64(total int64) constructor for this purpuse
