### PR TITLE
make sure /dev/tty file handle stays open

### DIFF
--- a/pb_x.go
+++ b/pb_x.go
@@ -14,14 +14,13 @@ const (
 	TIOCGWINSZ_OSX = 1074295912
 )
 
-var ttyFd uintptr
+var tty *os.File
 
 func init() {
-	tty, e := os.Open("/dev/tty")
-	if e != nil {
-		ttyFd = uintptr(syscall.Stdin)
-	} else {
-		ttyFd = tty.Fd()
+	var err error
+	tty, err = os.Open("/dev/tty")
+	if err != nil {
+		tty = os.Stdin
 	}
 }
 
@@ -36,7 +35,7 @@ func terminalWidth() (int, error) {
 		tio = TIOCGWINSZ_OSX
 	}
 	res, _, err := syscall.Syscall(sys_ioctl,
-		ttyFd,
+		tty.Fd(),
 		uintptr(tio),
 		uintptr(unsafe.Pointer(w)),
 	)


### PR DESCRIPTION
*os.File has a finalizer which will close the file when the *os.File
gets garbage collected. Because tty is only live for the duration of
init, it will eventually get collected, and ttyFd will contain a bad
file descriptor, causing the ioctl in terminalWidth to fail.

Instead, make tty a global variable, holding either our /dev/tty file or
os.Stdin (there should be no need for using syscall.Stdin.)
