### PR TITLE
Add an infinite progress when total count is unknown

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -97,7 +97,6 @@ func (pb *ProgressBar) Start() *ProgressBar {
 	pb.startTime = time.Now()
 	pb.startValue = pb.current
 	if pb.Total == 0 {
-		pb.ShowBar = false
 		pb.ShowTimeLeft = false
 		pb.ShowPercent = false
 	}
@@ -239,7 +238,7 @@ func (pb *ProgressBar) write(current int64) {
 		if pb.Total > 0 {
 			countersBox = fmt.Sprintf("%s / %s ", Format(current, pb.Units), Format(pb.Total, pb.Units))
 		} else {
-			countersBox = Format(current, pb.Units) + " "
+			countersBox = Format(current, pb.Units) + " / ? "
 		}
 	}
 
@@ -272,22 +271,36 @@ func (pb *ProgressBar) write(current int64) {
 	if pb.ShowBar {
 		size := width - len(countersBox+pb.BarStart+pb.BarEnd+percentBox+timeLeftBox+speedBox+pb.prefix+pb.postfix)
 		if size > 0 {
-			curCount := int(math.Ceil((float64(current) / float64(pb.Total)) * float64(size)))
-			emptCount := size - curCount
-			barBox = pb.BarStart
-			if emptCount < 0 {
-				emptCount = 0
-			}
-			if curCount > size {
-				curCount = size
-			}
-			if emptCount <= 0 {
-				barBox += strings.Repeat(pb.Current, curCount)
-			} else if curCount > 0 {
-				barBox += strings.Repeat(pb.Current, curCount-1) + pb.CurrentN
-			}
+			if pb.Total > 0 {
+				curCount := int(math.Ceil((float64(current) / float64(pb.Total)) * float64(size)))
+				emptCount := size - curCount
+				barBox = pb.BarStart
+				if emptCount < 0 {
+					emptCount = 0
+				}
+				if curCount > size {
+					curCount = size
+				}
+				if emptCount <= 0 {
+					barBox += strings.Repeat(pb.Current, curCount)
+				} else if curCount > 0 {
+					barBox += strings.Repeat(pb.Current, curCount-1) + pb.CurrentN
+				}
 
-			barBox += strings.Repeat(pb.Empty, emptCount) + pb.BarEnd
+				barBox += strings.Repeat(pb.Empty, emptCount) + pb.BarEnd
+			} else {
+
+				barBox = pb.BarStart
+				pos := size - int(current)%int(size)
+				if pos-1 > 0 {
+					barBox += strings.Repeat(pb.Empty, pos-1)
+				}
+				barBox += pb.Current
+				if size-pos-1 > 0 {
+					barBox += strings.Repeat(pb.Empty, size-pos-1)
+				}
+				barBox += pb.BarEnd
+			}
 		}
 	}
 

--- a/pb.go
+++ b/pb.go
@@ -100,7 +100,7 @@ func (pb *ProgressBar) Start() *ProgressBar {
 		pb.ShowBar = false
 		pb.ShowTimeLeft = false
 		pb.ShowPercent = false
-	}	
+	}
 	if !pb.ManualUpdate {
 		go pb.writer()
 	}
@@ -233,7 +233,7 @@ func (pb *ProgressBar) write(current int64) {
 		percent := float64(current) / (float64(pb.Total) / float64(100))
 		percentBox = fmt.Sprintf(" %#.02f %% ", percent)
 	}
-	
+
 	// counters
 	if pb.ShowCounters {
 		if pb.Total > 0 {


### PR DESCRIPTION
Sometimes we really don't know the total count to set to the progress bar, so I believe we should show an infinite progress in that case