### PR TITLE
fix ioctlReadTermios & ioctlWriteTermios on OSX

### DIFF
--- a/pb_x.go
+++ b/pb_x.go
@@ -18,9 +18,6 @@ const (
 	TIOCGWINSZ_OSX = 1074295912
 )
 
-const ioctlReadTermios = syscall.TCGETS
-const ioctlWriteTermios = syscall.TCSETS
-
 var tty *os.File
 
 var ErrPoolWasStarted = errors.New("Bar pool was started")

--- a/termios_bsd.go
+++ b/termios_bsd.go
@@ -1,0 +1,8 @@
+// +build darwin freebsd netbsd openbsd solaris dragonfly
+
+package pb
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA
+const ioctlWriteTermios = syscall.TIOCSETA

--- a/termios_linux.go
+++ b/termios_linux.go
@@ -1,0 +1,6 @@
+// +build linux
+
+package pb
+
+const ioctlReadTermios = 0x5401  // syscall.TCGETS
+const ioctlWriteTermios = 0x5402 // syscall.TCSETS


### PR DESCRIPTION
These values have been lifted from
golang/x/crypto/ssh/terminal/util_bsd.go

Fixes #54.