### PR TITLE
Add os to imports for Windows build.

### DIFF
--- a/pb_win.go
+++ b/pb_win.go
@@ -4,6 +4,7 @@ package pb
 
 import (
 	"github.com/olekukonko/ts"
+	"os"
 )
 
 var tty = os.Stdin


### PR DESCRIPTION
Otherwise the build fails, due to the usage of os.Stdin.

(Via slovokia@gmail.com).