### PR TITLE
Implement io.ReadWriteCloser for the Proxy

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -219,23 +219,9 @@ func (pb *ProgressBar) FinishPrint(str string) {
 	fmt.Println(str)
 }
 
-// implement io.Writer
-func (pb *ProgressBar) Write(p []byte) (n int, err error) {
-	n = len(p)
-	pb.Add(n)
-	return
-}
-
-// implement io.Reader
-func (pb *ProgressBar) Read(p []byte) (n int, err error) {
-	n = len(p)
-	pb.Add(n)
-	return
-}
-
 // Create new proxy reader over bar
-func (pb *ProgressBar) NewProxyReader(r io.Reader) *Reader {
-	return &Reader{r, pb}
+func (pb *ProgressBar) NewProxyReader(r io.ReadWriteCloser) *ReadWriteCloser {
+	return &ReadWriteCloser{r, pb}
 }
 
 func (pb *ProgressBar) write(current int64) {

--- a/reader.go
+++ b/reader.go
@@ -4,14 +4,24 @@ import (
 	"io"
 )
 
-// It's proxy reader, implement io.Reader
-type Reader struct {
-	io.Reader
+// It's proxy, implement io.ReadWriteCloser
+type ReadWriteCloser struct {
+	io.ReadWriteCloser
 	bar *ProgressBar
 }
 
-func (r *Reader) Read(p []byte) (n int, err error) {
-	n, err = r.Reader.Read(p)
+func (r *ReadWriteCloser) Read(p []byte) (n int, err error) {
+	n, err = r.ReadWriteCloser.Read(p)
 	r.bar.Add(n)
 	return
+}
+
+func (r *ReadWriteCloser) Write(p []byte) (n int, err error) {
+	n, err = r.ReadWriteCloser.Write(p)
+	r.bar.Add(n)
+	return
+}
+
+func (r *ReadWriteCloser) Close() error {
+	return r.ReadWriteCloser.Close()
 }


### PR DESCRIPTION
This is helpful when passing the proxy to things that will call close when the proxy conforms to io.Closer, eg https://golang.org/pkg/net/http/#NewRequest:

"If the provided body is also an io.Closer, the returned Request.Body is set to body and will be closed by the Client methods Do, Post, and PostForm, and Transport.RoundTrip."