### PR TITLE
Adding optional parameters to allow for more 'static' bars

### DIFF
--- a/format.go
+++ b/format.go
@@ -2,8 +2,8 @@ package pb
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
+	"time"
 )
 
 type Units int
@@ -16,13 +16,13 @@ const (
 )
 
 // Format integer
-func Format(i int64, units Units) string {
+func Format(i int64, units Units, width int) string {
 	switch units {
 	case U_BYTES:
 		return FormatBytes(i)
 	default:
 		// by default just convert to string
-		return strconv.FormatInt(i, 10)
+		return fmt.Sprintf(fmt.Sprintf("%%%dd", width), i)
 	}
 }
 
@@ -42,4 +42,13 @@ func FormatBytes(i int64) (result string) {
 	}
 	result = strings.Trim(result, " ")
 	return
+}
+
+func FormatDuration(d time.Duration) string {
+	res := ""
+	if d > time.Hour*24 {
+		res = fmt.Sprintf("%dd", d/24/time.Hour)
+		d -= (d / time.Hour / 24) * (time.Hour * 24)
+	}
+	return fmt.Sprintf("%s%v ", res, d)
 }

--- a/format_test.go
+++ b/format_test.go
@@ -9,7 +9,7 @@ import (
 func Test_DefaultsToInteger(t *testing.T) {
 	value := int64(1000)
 	expected := strconv.Itoa(int(value))
-	actual := Format(value, -1)
+	actual := Format(value, -1, 0)
 
 	if actual != expected {
 		t.Error(fmt.Sprintf("Expected {%s} was {%s}", expected, actual))
@@ -19,7 +19,7 @@ func Test_DefaultsToInteger(t *testing.T) {
 func Test_CanFormatAsInteger(t *testing.T) {
 	value := int64(1000)
 	expected := strconv.Itoa(int(value))
-	actual := Format(value, U_NO)
+	actual := Format(value, U_NO, 0)
 
 	if actual != expected {
 		t.Error(fmt.Sprintf("Expected {%s} was {%s}", expected, actual))
@@ -29,7 +29,7 @@ func Test_CanFormatAsInteger(t *testing.T) {
 func Test_CanFormatAsBytes(t *testing.T) {
 	value := int64(1000)
 	expected := "1000 B"
-	actual := Format(value, U_BYTES)
+	actual := Format(value, U_BYTES, 0)
 
 	if actual != expected {
 		t.Error(fmt.Sprintf("Expected {%s} was {%s}", expected, actual))


### PR DESCRIPTION
Hi,

I'm attaching some changes that allow users to set the bar up in a way that things remain in place. The summary of the changes are as the following:

1) Two new fields added: 
- UnitsWidth that allows the user to specify the width of the counters (not sizes).
- TimeBoxWidth allows the user to specify the width of the remaining time box.

2) Made the percentage fixed at 6 characters so the bar doesn't change size as progress is made.

3) Changed the time formatting function to write the number of days if the expected time exceeds 1 day.

Cheers!


