### PR TITLE
Add proper solaris fixes, additionally expose GetTerminalWidth() func…

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -349,6 +349,11 @@ func (pb *ProgressBar) write(current int64) {
 	}
 }
 
+// GetTerminalWidth - returns terminal width for all platforms.
+func GetTerminalWidth() (int, error) {
+	return terminalWidth()
+}
+
 func (pb *ProgressBar) GetWidth() int {
 	if pb.ForceWidth {
 		return pb.Width

--- a/pb_appengine.go
+++ b/pb_appengine.go
@@ -1,0 +1,11 @@
+// +build appengine
+
+package pb
+
+import "errors"
+
+// terminalWidth returns width of the terminal, which is not supported
+// and should always failed on appengine classic which is a sandboxed PaaS.
+func terminalWidth() (int, error) {
+	return 0, errors.New("Not supported")
+}

--- a/pb_nix.go
+++ b/pb_nix.go
@@ -1,7 +1,8 @@
 // +build linux darwin freebsd netbsd openbsd dragonfly
+// +build !appengine
 
 package pb
 
 import "syscall"
 
-const sys_ioctl = syscall.SYS_IOCTL
+const sysIoctl = syscall.SYS_IOCTL

--- a/pb_solaris.go
+++ b/pb_solaris.go
@@ -1,5 +1,6 @@
 // +build solaris
+// +build !appengine
 
 package pb
 
-const sys_ioctl = 54
+const sysIoctl = 54

--- a/pb_win.go
+++ b/pb_win.go
@@ -1,14 +1,17 @@
 // +build windows
+// +build !appengine
 
 package pb
 
 import (
-	"github.com/olekukonko/ts"
 	"os"
+
+	"github.com/olekukonko/ts"
 )
 
 var tty = os.Stdin
 
+// terminalWidth returns width of the terminal.
 func terminalWidth() (int, error) {
 	size, err := ts.GetSize()
 	return size.Col(), err

--- a/termios_bsd.go
+++ b/termios_bsd.go
@@ -1,4 +1,5 @@
-// +build darwin freebsd netbsd openbsd solaris dragonfly
+// +build darwin freebsd netbsd openbsd dragonfly
+// +build !appengine
 
 package pb
 

--- a/termios_nix.go
+++ b/termios_nix.go
@@ -1,4 +1,5 @@
-// +build linux
+// +build linux solaris
+// +build !appengine
 
 package pb
 


### PR DESCRIPTION
…tion.

- Fix syscall.SYS_IOCTL is not defined on illuminos/solaris.
- Fix syscall.{TIOCGETA,TIOCSETA} are not defined on illuminos/solaris.

GetTerminalWidth is exposed for pb callers to inspect on current
terminal width.