### PR TITLE
Refactor formatting

### DIFF
--- a/format.go
+++ b/format.go
@@ -9,25 +9,67 @@ import (
 type Units int
 
 const (
-	// By default, without type handle
+	// U_NO are default units, they represent a simple value and are not formatted at all.
 	U_NO Units = iota
-	// Handle as b, Kb, Mb, etc
+	// U_BYTES units are formatted in a human readable way (b, Bb, Mb, ...)
 	U_BYTES
+	// U_DURATION units are formatted in a human readable way (3h14m15s)
+	U_DURATION
 )
 
-// Format integer
-func Format(i int64, units Units, width int) string {
-	switch units {
+func Format(i int64) *formatter {
+	return &formatter{n: i}
+}
+
+type formatter struct {
+	n      int64
+	unit   Units
+	width  int
+	perSec bool
+}
+
+func (f *formatter) Value(n int64) *formatter {
+	f.n = n
+	return f
+}
+
+func (f *formatter) To(unit Units) *formatter {
+	f.unit = unit
+	return f
+}
+
+func (f *formatter) Width(width int) *formatter {
+	f.width = width
+	return f
+}
+
+func (f *formatter) PerSec() *formatter {
+	f.perSec = true
+	return f
+}
+
+func (f *formatter) String() (out string) {
+	switch f.unit {
 	case U_BYTES:
-		return FormatBytes(i)
+		return formatBytes(f.n)
+	case U_DURATION:
+		d := time.Duration(f.n)
+		if d > time.Hour*24 {
+			out = fmt.Sprintf("%dd", d/24/time.Hour)
+			d -= (d / time.Hour / 24) * (time.Hour * 24)
+		}
+		out = fmt.Sprintf("%s%v", out, d)
 	default:
-		// by default just convert to string
-		return fmt.Sprintf(fmt.Sprintf("%%%dd", width), i)
+		out = fmt.Sprintf(fmt.Sprintf("%%%dd", f.width), f.n)
 	}
+	if f.perSec {
+		out += "/s"
+	}
+	return
 }
 
 // Convert bytes to human readable string. Like a 2 MB, 64.2 KB, 52 B
-func FormatBytes(i int64) (result string) {
+func formatBytes(i int64) (result string) {
 	switch {
 	case i > (1024 * 1024 * 1024 * 1024):
 		result = fmt.Sprintf("%.02f TB", float64(i)/1024/1024/1024/1024)
@@ -42,13 +84,4 @@ func FormatBytes(i int64) (result string) {
 	}
 	result = strings.Trim(result, " ")
 	return
-}
-
-func FormatDuration(d time.Duration) string {
-	res := ""
-	if d > time.Hour*24 {
-		res = fmt.Sprintf("%dd", d/24/time.Hour)
-		d -= (d / time.Hour / 24) * (time.Hour * 24)
-	}
-	return fmt.Sprintf("%s%v ", res, d)
 }

--- a/format_test.go
+++ b/format_test.go
@@ -1,15 +1,17 @@
-package pb
+package pb_test
 
 import (
 	"fmt"
+	"github.com/cheggaaa/pb"
 	"strconv"
 	"testing"
+	"time"
 )
 
 func Test_DefaultsToInteger(t *testing.T) {
 	value := int64(1000)
 	expected := strconv.Itoa(int(value))
-	actual := Format(value, -1, 0)
+	actual := pb.Format(value).String()
 
 	if actual != expected {
 		t.Error(fmt.Sprintf("Expected {%s} was {%s}", expected, actual))
@@ -19,7 +21,7 @@ func Test_DefaultsToInteger(t *testing.T) {
 func Test_CanFormatAsInteger(t *testing.T) {
 	value := int64(1000)
 	expected := strconv.Itoa(int(value))
-	actual := Format(value, U_NO, 0)
+	actual := pb.Format(value).To(pb.U_NO).String()
 
 	if actual != expected {
 		t.Error(fmt.Sprintf("Expected {%s} was {%s}", expected, actual))
@@ -29,8 +31,26 @@ func Test_CanFormatAsInteger(t *testing.T) {
 func Test_CanFormatAsBytes(t *testing.T) {
 	value := int64(1000)
 	expected := "1000 B"
-	actual := Format(value, U_BYTES, 0)
+	actual := pb.Format(value).To(pb.U_BYTES).String()
 
+	if actual != expected {
+		t.Error(fmt.Sprintf("Expected {%s} was {%s}", expected, actual))
+	}
+}
+
+func Test_CanFormatDuration(t *testing.T) {
+	value := 10 * time.Minute
+	expected := "10m0s"
+	actual := pb.Format(int64(value)).To(pb.U_DURATION).String()
+	if actual != expected {
+		t.Error(fmt.Sprintf("Expected {%s} was {%s}", expected, actual))
+	}
+}
+
+func Test_DefaultUnitsWidth(t *testing.T) {
+	value := 10
+	expected := "     10"
+	actual := pb.Format(int64(value)).Width(7).String()
 	if actual != expected {
 		t.Error(fmt.Sprintf("Expected {%s} was {%s}", expected, actual))
 	}

--- a/pb.go
+++ b/pb.go
@@ -31,7 +31,7 @@ func New(total int) *ProgressBar {
 	return New64(int64(total))
 }
 
-// Create new progress bar object uding int64 as total
+// Create new progress bar object using int64 as total
 func New64(total int64) *ProgressBar {
 	pb := &ProgressBar{
 		Total:         total,
@@ -79,7 +79,7 @@ type ProgressBar struct {
 	ForceWidth                       bool
 	ManualUpdate                     bool
 
-	// default width for unit numbers and time box
+	// Default width for the time box.
 	UnitsWidth   int
 	TimeBoxWidth int
 
@@ -261,10 +261,12 @@ func (pb *ProgressBar) write(current int64) {
 
 	// counters
 	if pb.ShowCounters {
+		current := Format(current).To(pb.Units).Width(pb.UnitsWidth)
 		if pb.Total > 0 {
-			countersBox = fmt.Sprintf("%s / %s ", Format(current, pb.Units, pb.UnitsWidth), Format(pb.Total, pb.Units, pb.UnitsWidth))
+			total := Format(pb.Total).To(pb.Units).Width(pb.UnitsWidth)
+			countersBox = fmt.Sprintf("%s / %s ", current, total)
 		} else {
-			countersBox = Format(current, pb.Units, pb.UnitsWidth) + " / ? "
+			countersBox = fmt.Sprintf(" %s / ? ", current)
 		}
 	}
 
@@ -293,7 +295,8 @@ func (pb *ProgressBar) write(current int64) {
 				left = time.Duration(currentFromStart) * perEntry
 				left = (left / time.Second) * time.Second
 			}
-			timeLeftBox = FormatDuration(left)
+			timeLeft := Format(int64(left)).To(U_DURATION).String()
+			timeLeftBox = fmt.Sprintf("%s ", timeLeft)
 		}
 	}
 
@@ -305,7 +308,7 @@ func (pb *ProgressBar) write(current int64) {
 	if pb.ShowSpeed && currentFromStart > 0 {
 		fromStart := time.Now().Sub(pb.startTime)
 		speed := float64(currentFromStart) / (float64(fromStart) / float64(time.Second))
-		speedBox = Format(int64(speed), pb.Units, pb.UnitsWidth) + "/s "
+		speedBox = Format(int64(speed)).To(pb.Units).Width(pb.UnitsWidth).PerSec().String()
 	}
 
 	barWidth := escapeAwareRuneCountInString(countersBox + pb.BarStart + pb.BarEnd + percentBox + timeLeftBox + speedBox + pb.prefix + pb.postfix)


### PR DESCRIPTION
I thought I would share this patch, feel free to reject tho, I understand this might be opinionated.

I also played around with UnitsWidth and couldn't make a difference, I fail to see where its trimmed, so effectively has no effect.

---
This patch unifies and centralises all unit formatting under the formatter.String() umbrella.

It also gets rid of the UnitsWidth attribute, which even if used by format, assigning values to it did not have any real effect on the final output.