### PR TITLE
readme: make example compile and comply to format rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,36 +131,39 @@ package main
 
 import (
     "math/rand"
-    "github.com/cheggaaa/pb"    
     "sync"
     "time"
+
+    "github.com/cheggaaa/pb"
 )
 
-// create bars
-first := pb.New(200).Prefix("First ")
-second := pb.New(200).Prefix("Second ")
-third := pb.New(200).Prefix("Third ")
-// start pool
-pool, err := pb.StartPool(first, second, third)
-if err != nil {
-	panic(err)
+func main() {
+    // create bars
+    first := pb.New(200).Prefix("First ")
+    second := pb.New(200).Prefix("Second ")
+    third := pb.New(200).Prefix("Third ")
+    // start pool
+    pool, err := pb.StartPool(first, second, third)
+    if err != nil {
+        panic(err)
+    }
+    // update bars
+    wg := new(sync.WaitGroup)
+    for _, bar := range []*pb.ProgressBar{first, second, third} {
+        wg.Add(1)
+        go func(cb *pb.ProgressBar) {
+            for n := 0; n < 200; n++ {
+                cb.Increment()
+                time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
+            }
+            cb.Finish()
+            wg.Done()
+        }(bar)
+    }
+    wg.Wait()
+    // close pool
+    pool.Stop()
 }
-// update bars
-wg := new(sync.WaitGroup)
-for _, bar := range []*pb.ProgressBar{first, second, third} {
-	wg.Add(1)
-	go func(cb *pb.ProgressBar) {
-		for n := 0; n < 200; n++ {
-			cb.Increment()
-			time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
-		}
-		cb.Finish()
-		wg.Done()
-	}(bar)
-}
-wg.Wait()
-// close pool
-pool.Stop()
 ```
 
 The result will be as follows:


### PR DESCRIPTION
This patch makes the multi-line example:
- compile by adding a main function
- comply to go fmt 
I checked that the example compiles and works.