### PR TITLE
Add 1 space in front of the final time

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -285,7 +285,7 @@ func (pb *ProgressBar) write(current int64) {
 			} else {
 				left = (time.Duration(currentFromStart) / time.Second) * time.Second
 			}
-			timeLeftBox = left.String()
+			timeLeftBox = fmt.Sprintf(" %s", left.String())
 		}
 	default:
 		if pb.ShowTimeLeft && currentFromStart > 0 {


### PR DESCRIPTION
Using `bar.ShowFinalTime = true` this is always happens:

    Apr  1 16:24:05 78 / 78 [===================[…snip…]===================] 100.00%27m20s

No matter what configuration options are in use (as far as I can test) there is never a space between the previous element and the final time. So I added it. :sweat_smile: 