### PR TITLE
Show the final time when total count is unknown

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -289,11 +289,7 @@ func (pb *ProgressBar) write(current int64) {
 	case <-pb.finish:
 		if pb.ShowFinalTime {
 			var left time.Duration
-			if pb.Total > 0 {
-				left = (fromStart / time.Second) * time.Second
-			} else {
-				left = (time.Duration(currentFromStart) / time.Second) * time.Second
-			}
+			left = (fromStart / time.Second) * time.Second
 			timeLeftBox = fmt.Sprintf(" %s", left.String())
 		}
 	default:


### PR DESCRIPTION
Current code doesn't show the final time when total count is not set. So I fixed it to show the time.

### sample code
```
package main

import (
	"time"

	pb "gopkg.in/cheggaaa/pb.v1"
)

func main() {
	count := 10000
	bar := pb.StartNew(0)
	for i := 0; i < count; i++ {
		bar.Increment()
		time.Sleep(time.Millisecond)
	}
	bar.FinishPrint("The End!")
}
```

### result (before)
```
10000 / ? [-----------------------------=----------------------------] 0s 
The End!
```

### result (after)
```
10000 / ? [-----------------------------=----------------------------] 12s 
The End!
```