### PR TITLE
fix data race on Finish()

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -379,9 +379,10 @@ func (pb *ProgressBar) write(current int64) {
 	// and print!
 	pb.mu.Lock()
 	pb.lastPrint = out + end
+	isFinish := pb.isFinish
 	pb.mu.Unlock()
 	switch {
-	case pb.isFinish:
+	case isFinish:
 		return
 	case pb.Output != nil:
 		fmt.Fprint(pb.Output, "\r"+out+end)


### PR DESCRIPTION
Finish() call could trigger a data race

See callstack bellow
```
WARNING: DATA RACE
Write at 0x00c420417e80 by main goroutine:
  github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb%2ev1.(*ProgressBar).Finish.func1()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb.v1/pb.go:232 +0x14b
  sync.(*Once).Do()
      /usr/local/go/src/sync/once.go:44 +0xf2
  github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb%2ev1.(*ProgressBar).Finish()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb.v1/pb.go:233 +0x8b
  github.com/d33d33/mirror/cmd.glob..func1()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/cmd/root.go:239 +0x1d60
  github.com/d33d33/mirror/vendor/github.com/spf13/cobra.(*Command).execute()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/vendor/github.com/spf13/cobra/command.go:636 +0x805
  github.com/d33d33/mirror/vendor/github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/vendor/github.com/spf13/cobra/command.go:722 +0x545
  github.com/d33d33/mirror/vendor/github.com/spf13/cobra.(*Command).Execute()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/vendor/github.com/spf13/cobra/command.go:681 +0x38
  main.main()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/mirror.go:11 +0x56

Previous read at 0x00c420417e80 by goroutine 19:
  github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb%2ev1.(*ProgressBar).write()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb.v1/pb.go:384 +0x90c
  github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb%2ev1.(*ProgressBar).Update()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb.v1/pb.go:418 +0x84
  github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb%2ev1.(*ProgressBar).refresher()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb.v1/pb.go:445 +0x130

Goroutine 19 (finished) created at:
  github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb%2ev1.(*ProgressBar).Start()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb.v1/pb.go:122 +0x153
  github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb%2ev1.StartNew()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/vendor/gopkg.in/cheggaaa/pb.v1/pb.go:57 +0x46
  github.com/d33d33/mirror/cmd.glob..func1()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/cmd/root.go:146 +0xe33
  github.com/d33d33/mirror/vendor/github.com/spf13/cobra.(*Command).execute()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/vendor/github.com/spf13/cobra/command.go:636 +0x805
  github.com/d33d33/mirror/vendor/github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/vendor/github.com/spf13/cobra/command.go:722 +0x545
  github.com/d33d33/mirror/vendor/github.com/spf13/cobra.(*Command).Execute()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/vendor/github.com/spf13/cobra/command.go:681 +0x38
  main.main()
      /Users/d33d33/workspaces/go/src/github.com/d33d33/mirror/mirror.go:11 +0x56
```