### PR TITLE
Fixes data race for writing conditionally based on unprotected value

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -47,7 +47,6 @@ func New64(total int64) *ProgressBar {
 		Units:         U_NO,
 		ManualUpdate:  false,
 		finish:        make(chan struct{}),
-		currentValue:  -1,
 	}
 	return pb.Format(FORMAT)
 }
@@ -90,9 +89,8 @@ type ProgressBar struct {
 	finish     chan struct{}
 	isFinish   bool
 
-	startTime    time.Time
-	startValue   int64
-	currentValue int64
+	startTime  time.Time
+	startValue int64
 
 	prefix, postfix string
 
@@ -415,9 +413,8 @@ func (pb *ProgressBar) GetWidth() int {
 // Write the current state of the progressbar
 func (pb *ProgressBar) Update() {
 	c := atomic.LoadInt64(&pb.current)
-	if pb.AlwaysUpdate || c != pb.currentValue {
+	if pb.AlwaysUpdate {
 		pb.write(c)
-		pb.currentValue = c
 	}
 	if pb.AutoStat {
 		if c == 0 {

--- a/pb_test.go
+++ b/pb_test.go
@@ -3,6 +3,7 @@ package pb
 import (
 	"bytes"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,6 +40,25 @@ func Test_MultipleFinish(t *testing.T) {
 	bar := New(5000)
 	bar.Add(2000)
 	bar.Finish()
+	bar.Finish()
+}
+
+func TestWriteRace(t *testing.T) {
+	outBuffer := &bytes.Buffer{}
+	totalCount := 20
+	bar := New(totalCount)
+	bar.Output = outBuffer
+	bar.Start()
+	var wg sync.WaitGroup
+	for i := 0; i < totalCount; i++ {
+		wg.Add(1)
+		go func() {
+			bar.Increment()
+			time.Sleep(250 * time.Millisecond)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 	bar.Finish()
 }
 


### PR DESCRIPTION
Fixes #102 

Removing the condition to update the bar based on progress value. The user can set the refresh rate if they want to adjust how often it updates. Since you can also manually update the bar it is a pre-optimization that is causing a data race. 

Just removing the variable from the bar as its not really providing huge value.