### PR TITLE
add U_BYTES_DEC format

### DIFF
--- a/format.go
+++ b/format.go
@@ -10,8 +10,10 @@ type Units int
 const (
 	// U_NO are default units, they represent a simple value and are not formatted at all.
 	U_NO Units = iota
-	// U_BYTES units are formatted in a human readable way (b, Bb, Mb, ...)
+	// U_BYTES units are formatted in a human readable way (B, KiB, MiB, ...)
 	U_BYTES
+	// U_BYTES_DEC units are like U_BYTES, but base 10 (B, KB, MB, ...)
+	U_BYTES_DEC
 	// U_DURATION units are formatted in a human readable way (3h14m15s)
 	U_DURATION
 )
@@ -21,6 +23,11 @@ const (
 	MiB = 1048576
 	GiB = 1073741824
 	TiB = 1099511627776
+
+	KB = 1e3
+	MB = 1e6
+	GB = 1e9
+	TB = 1e12
 )
 
 func Format(i int64) *formatter {
@@ -53,6 +60,8 @@ func (f *formatter) String() (out string) {
 	switch f.unit {
 	case U_BYTES:
 		out = formatBytes(f.n)
+	case U_BYTES_DEC:
+		out = formatBytesDec(f.n)
 	case U_DURATION:
 		out = formatDuration(f.n)
 	default:
@@ -64,7 +73,7 @@ func (f *formatter) String() (out string) {
 	return
 }
 
-// Convert bytes to human readable string. Like a 2 MiB, 64.2 KiB, 52 B
+// Convert bytes to human readable string. Like 2 MiB, 64.2 KiB, 52 B
 func formatBytes(i int64) (result string) {
 	switch {
 	case i >= TiB:
@@ -75,6 +84,23 @@ func formatBytes(i int64) (result string) {
 		result = fmt.Sprintf("%.02f MiB", float64(i)/MiB)
 	case i >= KiB:
 		result = fmt.Sprintf("%.02f KiB", float64(i)/KiB)
+	default:
+		result = fmt.Sprintf("%d B", i)
+	}
+	return
+}
+
+// Convert bytes to base-10 human readable string. Like 2 MB, 64.2 KB, 52 B
+func formatBytesDec(i int64) (result string) {
+	switch {
+	case i >= TB:
+		result = fmt.Sprintf("%.02f TB", float64(i)/TB)
+	case i >= GB:
+		result = fmt.Sprintf("%.02f GB", float64(i)/GB)
+	case i >= MB:
+		result = fmt.Sprintf("%.02f MB", float64(i)/MB)
+	case i >= KB:
+		result = fmt.Sprintf("%.02f KB", float64(i)/KB)
 	default:
 		result = fmt.Sprintf("%d B", i)
 	}

--- a/format_test.go
+++ b/format_test.go
@@ -47,6 +47,26 @@ func Test_CanFormatAsBytes(t *testing.T) {
 	}
 }
 
+func Test_CanFormatAsBytesDec(t *testing.T) {
+	inputs := []struct {
+		v int64
+		e string
+	}{
+		{v: 999, e: "999 B"},
+		{v: 1024, e: "1.02 KB"},
+		{v: 3*MB + 140*KB, e: "3.14 MB"},
+		{v: 2 * GB, e: "2.00 GB"},
+		{v: 2048 * GB, e: "2.05 TB"},
+	}
+
+	for _, input := range inputs {
+		actual := Format(input.v).To(U_BYTES_DEC).String()
+		if actual != input.e {
+			t.Error(fmt.Sprintf("Expected {%s} was {%s}", input.e, actual))
+		}
+	}
+}
+
 func Test_CanFormatDuration(t *testing.T) {
 	value := 10 * time.Minute
 	expected := "10m0s"


### PR DESCRIPTION
open to suggestions on the naming. `BYTES_DEC` feels clunky to me, but perhaps it's the most clear.