### PR TITLE
Fix the v2 branch for Solaris/Illumos.

### DIFF
--- a/termutil/term_linux.go
+++ b/termutil/term_linux.go
@@ -1,4 +1,4 @@
-// +build linux solaris
+// +build linux
 // +build !appengine
 
 package termutil

--- a/termutil/term_solaris.go
+++ b/termutil/term_solaris.go
@@ -3,4 +3,6 @@
 
 package termutil
 
+const ioctlReadTermios = 0x5401  // syscall.TCGETS
+const ioctlWriteTermios = 0x5402 // syscall.TCSETS
 const sysIoctl = 54


### PR DESCRIPTION
Without this fix the `v2` branch doesn't test or compile against Illumos/Solaris.

```
$ go test -v                                                                                                  
=== RUN   TestElementPercent                                                                                                                                  
--- PASS: TestElementPercent (0.00s)                                                                                                                          
=== RUN   TestElementCounters                                                                                                                                 
--- PASS: TestElementCounters (0.00s)  
=== RUN   TestElementBar               
--- PASS: TestElementBar (0.23s)       
=== RUN   TestElementSpeed             
--- PASS: TestElementSpeed (0.00s)     
=== RUN   TestElementRemainingTime     
--- PASS: TestElementRemainingTime (0.00s)                                     
=== RUN   TestElementElapsedTime       
--- PASS: TestElementElapsedTime (0.00s)                                       
=== RUN   TestElementString            
--- PASS: TestElementString (0.00s)    
=== RUN   TestElementCycle             
--- PASS: TestElementCycle (0.00s)     
=== RUN   TestAdaptiveWrap             
--- PASS: TestAdaptiveWrap (0.00s)     
=== RUN   TestRegisterElement          
--- PASS: TestRegisterElement (0.00s)  
=== RUN   TestPBBasic                  
--- PASS: TestPBBasic (0.00s)          
=== RUN   TestPBWidth                  
--- PASS: TestPBWidth (0.00s)          
=== RUN   TestPBTemplate               
--- PASS: TestPBTemplate (0.00s)       
=== RUN   TestPBStartFinish            
--- PASS: TestPBStartFinish (0.20s)    
=== RUN   TestPBFlags                  
--- PASS: TestPBFlags (0.00s)          
=== RUN   TestPBProxyReader            
--- PASS: TestPBProxyReader (0.00s)    
=== RUN   TestProgressBarTemplate      
--- PASS: TestProgressBarTemplate (0.00s)                                      
=== RUN   TestTemplateFuncs            
--- PASS: TestTemplateFuncs (0.00s)    
=== RUN   TestUtilCellCount            
--- PASS: TestUtilCellCount (0.00s)    
=== RUN   TestUtilStripString          
--- PASS: TestUtilStripString (0.00s)  
=== RUN   TestUtilRound                
--- PASS: TestUtilRound (0.00s)        
=== RUN   TestUtilFormatBytes          
--- PASS: TestUtilFormatBytes (0.00s)  
PASS                                   
ok      github.com/cheggaaa/pb  0.465s 
```

Without the patch:

```
$ go test -v
# gopkg.in/cheggaaa/pb.v2/termutil
../../../gopkg.in/cheggaaa/pb.v2/termutil/term_x.go:48:47: undefined: ioctlReadTermios
../../../gopkg.in/cheggaaa/pb.v2/termutil/term_x.go:57:47: undefined: ioctlWriteTermios
../../../gopkg.in/cheggaaa/pb.v2/termutil/term_x.go:66:47: undefined: ioctlWriteTermios
FAIL    github.com/cheggaaa/pb [build failed]
```