### PR TITLE
Improve the portability of termios handling.

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -467,10 +467,3 @@ func (pb *ProgressBar) refresher() {
 		}
 	}
 }
-
-type window struct {
-	Row    uint16
-	Col    uint16
-	Xpixel uint16
-	Ypixel uint16
-}

--- a/pb_nix.go
+++ b/pb_nix.go
@@ -1,8 +1,0 @@
-// +build linux darwin freebsd netbsd openbsd dragonfly
-// +build !appengine
-
-package pb
-
-import "syscall"
-
-const sysIoctl = syscall.SYS_IOCTL

--- a/pb_solaris.go
+++ b/pb_solaris.go
@@ -1,6 +1,0 @@
-// +build solaris
-// +build !appengine
-
-package pb
-
-const sysIoctl = 54

--- a/pb_x.go
+++ b/pb_x.go
@@ -8,25 +8,24 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"runtime"
 	"sync"
 	"syscall"
-	"unsafe"
-)
 
-const (
-	TIOCGWINSZ     = 0x5413
-	TIOCGWINSZ_OSX = 1074295912
+	"golang.org/x/sys/unix"
 )
-
-var tty *os.File
 
 var ErrPoolWasStarted = errors.New("Bar pool was started")
 
-var echoLocked bool
-var echoLockMutex sync.Mutex
+var (
+	echoLockMutex    sync.Mutex
+	origTermStatePtr *unix.Termios
+	tty              *os.File
+)
 
 func init() {
+	echoLockMutex.Lock()
+	defer echoLockMutex.Unlock()
+
 	var err error
 	tty, err = os.Open("/dev/tty")
 	if err != nil {
@@ -36,64 +35,63 @@ func init() {
 
 // terminalWidth returns width of the terminal.
 func terminalWidth() (int, error) {
-	w := new(window)
-	tio := syscall.TIOCGWINSZ
-	if runtime.GOOS == "darwin" {
-		tio = TIOCGWINSZ_OSX
-	}
-	res, _, err := syscall.Syscall(sysIoctl,
-		tty.Fd(),
-		uintptr(tio),
-		uintptr(unsafe.Pointer(w)),
-	)
-	if int(res) == -1 {
+	echoLockMutex.Lock()
+	defer echoLockMutex.Unlock()
+
+	fd := int(tty.Fd())
+
+	ws, err := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
+	if err != nil {
 		return 0, err
 	}
-	return int(w.Col), nil
-}
 
-var oldState syscall.Termios
+	return int(ws.Col), nil
+}
 
 func lockEcho() (quit chan int, err error) {
 	echoLockMutex.Lock()
 	defer echoLockMutex.Unlock()
-	if echoLocked {
-		err = ErrPoolWasStarted
-		return
-	}
-	echoLocked = true
-
-	fd := tty.Fd()
-	if _, _, e := syscall.Syscall6(sysIoctl, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&oldState)), 0, 0, 0); e != 0 {
-		err = fmt.Errorf("Can't get terminal settings: %v", e)
-		return
+	if origTermStatePtr != nil {
+		return quit, ErrPoolWasStarted
 	}
 
-	newState := oldState
-	newState.Lflag &^= syscall.ECHO
-	newState.Lflag |= syscall.ICANON | syscall.ISIG
-	newState.Iflag |= syscall.ICRNL
-	if _, _, e := syscall.Syscall6(sysIoctl, fd, ioctlWriteTermios, uintptr(unsafe.Pointer(&newState)), 0, 0, 0); e != 0 {
-		err = fmt.Errorf("Can't set terminal settings: %v", e)
-		return
+	fd := int(tty.Fd())
+
+	oldTermStatePtr, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
+	if err != nil {
+		return nil, fmt.Errorf("Can't get terminal settings: %v", err)
 	}
+
+	oldTermios := *oldTermStatePtr
+	newTermios := oldTermios
+	newTermios.Lflag &^= syscall.ECHO
+	newTermios.Lflag |= syscall.ICANON | syscall.ISIG
+	newTermios.Iflag |= syscall.ICRNL
+	if err := unix.IoctlSetTermios(fd, ioctlWriteTermios, &newTermios); err != nil {
+		return nil, fmt.Errorf("Can't set terminal settings: %v", err)
+	}
+
 	quit = make(chan int, 1)
 	go catchTerminate(quit)
 	return
 }
 
-func unlockEcho() (err error) {
+func unlockEcho() error {
 	echoLockMutex.Lock()
 	defer echoLockMutex.Unlock()
-	if !echoLocked {
-		return
+	if origTermStatePtr == nil {
+		return nil
 	}
-	echoLocked = false
-	fd := tty.Fd()
-	if _, _, e := syscall.Syscall6(sysIoctl, fd, ioctlWriteTermios, uintptr(unsafe.Pointer(&oldState)), 0, 0, 0); e != 0 {
-		err = fmt.Errorf("Can't set terminal settings")
+
+	fd := int(tty.Fd())
+
+	if err := unix.IoctlSetTermios(fd, ioctlWriteTermios, origTermStatePtr); err != nil {
+		return fmt.Errorf("Can't set terminal settings: %v", err)
 	}
-	return
+
+	origTermStatePtr = nil
+
+	return nil
 }
 
 // listen exit signals and restore terminal state

--- a/termios_nix.go
+++ b/termios_nix.go
@@ -1,7 +1,0 @@
-// +build linux solaris
-// +build !appengine
-
-package pb
-
-const ioctlReadTermios = 0x5401  // syscall.TCGETS
-const ioctlWriteTermios = 0x5402 // syscall.TCSETS

--- a/termios_sysv.go
+++ b/termios_sysv.go
@@ -1,0 +1,13 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux solaris
+// +build !appengine
+
+package pb
+
+import "golang.org/x/sys/unix"
+
+const ioctlReadTermios = unix.TCGETS
+const ioctlWriteTermios = unix.TCSETS


### PR DESCRIPTION
Previously this was using the `syscall` package.  All of the helper functions that were likely missing at the time this was written are now available under the `golang.org/x/sys/unix` package.

Consumers of this library will need to add `golang.org/x/sys/unix` as a dependency.

Hat-tip to `golang.org/x/crypto/ssh/terminal` for having most of the necessary bits already stubbed out and available for easy reuse.  Similarly, this code should be much more future-proof given its reliance on `golang.org/x/sys/unix`.  I almost went down the route of using `x/crypto/ssh/terminal` but it doesn't export its embedded `unix.Termios` struct.

This PR is required in order to prevent problems with relocatable symbols:

```
# github.com/ovh/venom/cli/venom                                                                                                                              
github.com/ovh/venom/vendor/golang.org/x/sys/unix.Syscall6: call to external function
github.com/ovh/venom/vendor/gopkg.in/cheggaaa/pb%!e(string=github.com/ovh/venom/vendor/golang.org/x/sys/unix.Syscall6)v1.lockEcho: relocation target %!s(MISSI
NG) not defined                                                                
github.com/ovh/venom/vendor/gopkg.in/cheggaaa/pb%!e(string=github.com/ovh/venom/vendor/golang.org/x/sys/unix.Syscall6)v1.lockEcho: relocation target %!s(MISSI
NG) not defined                                                                                                                                               
github.com/ovh/venom/vendor/gopkg.in/cheggaaa/pb%!e(string=github.com/ovh/venom/vendor/golang.org/x/sys/unix.Syscall6)v1.unlockEcho: relocation target %!s(MIS
SING) not defined                                                              
github.com/ovh/venom/vendor/gopkg.in/cheggaaa/pb%!e(string=github.com/ovh/venom/vendor/golang.org/x/sys/unix.Syscall6)v1.lockEcho: undefined: %!q(MISSING)
github.com/ovh/venom/vendor/gopkg.in/cheggaaa/pb%!e(string=github.com/ovh/venom/vendor/golang.org/x/sys/unix.Syscall6)v1.lockEcho: undefined: %!q(MISSING)
github.com/ovh/venom/vendor/gopkg.in/cheggaaa/pb%!e(string=github.com/ovh/venom/vendor/golang.org/x/sys/unix.Syscall6)v1.unlockEcho: undefined: %!q(MISSING)
```