### PR TITLE
Ensure that all bars finish printing before exiting.

### DIFF
--- a/pb_win.go
+++ b/pb_win.go
@@ -102,7 +102,7 @@ var echoLockMutex sync.Mutex
 
 var oldState word
 
-func lockEcho() (quit chan int, err error) {
+func lockEcho() (shutdownCh chan struct{}, err error) {
 	echoLockMutex.Lock()
 	defer echoLockMutex.Unlock()
 	if echoLocked {

--- a/pb_x.go
+++ b/pb_x.go
@@ -48,11 +48,11 @@ func terminalWidth() (int, error) {
 	return int(ws.Col), nil
 }
 
-func lockEcho() (quit chan int, err error) {
+func lockEcho() (shutdownCh chan struct{}, err error) {
 	echoLockMutex.Lock()
 	defer echoLockMutex.Unlock()
 	if origTermStatePtr != nil {
-		return quit, ErrPoolWasStarted
+		return shutdownCh, ErrPoolWasStarted
 	}
 
 	fd := int(tty.Fd())
@@ -71,8 +71,8 @@ func lockEcho() (quit chan int, err error) {
 		return nil, fmt.Errorf("Can't set terminal settings: %v", err)
 	}
 
-	quit = make(chan int, 1)
-	go catchTerminate(quit)
+	shutdownCh = make(chan struct{})
+	go catchTerminate(shutdownCh)
 	return
 }
 
@@ -95,12 +95,12 @@ func unlockEcho() error {
 }
 
 // listen exit signals and restore terminal state
-func catchTerminate(quit chan int) {
+func catchTerminate(shutdownCh chan struct{}) {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGKILL)
 	defer signal.Stop(sig)
 	select {
-	case <-quit:
+	case <-shutdownCh:
 		unlockEcho()
 	case <-sig:
 		unlockEcho()


### PR DESCRIPTION
Without this fix it's possible that a bar may not finish printing before the call to `Stop()` returns and therefore the calling program exits.