### PR TITLE
Update Travis to include something more modern than 1.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go:
-- 1.4.2
+- 1.4
+- 1.9
+- master
 sudo: false
 os:
 - linux


### PR DESCRIPTION
Maybe it's time to drop 1.4?  The latest stable + `master` should be sufficient.