### PR TITLE
Allow for initialising a pool without starting it

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -12,9 +12,17 @@ import (
 // You need call pool.Stop() after work
 func StartPool(pbs ...*ProgressBar) (pool *Pool, err error) {
 	pool = new(Pool)
-	if err = pool.start(); err != nil {
+	if err = pool.Start(); err != nil {
 		return
 	}
+	pool.Add(pbs...)
+	return
+}
+
+// NewPool initialises a pool with progress bars, but
+// doesn't start it. You need to call Start manually
+func NewPool(pbs ...*ProgressBar) (pool *Pool) {
+	pool = new(Pool)
 	pool.Add(pbs...)
 	return
 }
@@ -42,7 +50,7 @@ func (p *Pool) Add(pbs ...*ProgressBar) {
 	}
 }
 
-func (p *Pool) start() (err error) {
+func (p *Pool) Start() (err error) {
 	p.RefreshRate = DefaultRefreshRate
 	p.shutdownCh, err = lockEcho()
 	if err != nil {


### PR DESCRIPTION
Maybe fixes #123

It's not perfect however: https://youtu.be/Oo_L_MHvEmo. In the video pb.go is:

```go
package main

import (
	"math/rand"
	"os"
	"sync"
	"time"

	"github.com/wjessop/pb"
)

func main() {
	// create bars
	first := pb.New64(1000).Prefix("one ").SetUnits(pb.U_BYTES)
	second := pb.New64(1000).Prefix("two ").SetUnits(pb.U_BYTES)

	first.Output = os.Stderr
	second.Output = os.Stderr

	// start pool
	// pool, err := pb.StartPool(first, second)
	pool := pb.NewPool()
	pool.Output = os.Stderr
	err := pool.Start()
	if err != nil {
		panic(err)
	}

	// update bars
	wg := new(sync.WaitGroup)
	for _, bar := range []*pb.ProgressBar{first, second} {
		wg.Add(1)
		go func(cb *pb.ProgressBar) {
			for n := 0; n < 200; n++ {
				// cb.Increment()
				time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
				cb.Add(5)
			}
			cb.Finish()
			wg.Done()
		}(bar)
	}
	wg.Wait()
	// close pool
	pool.Stop()
}
```