### PR TITLE
Fix panic with multiple bars in Windows

### DIFF
--- a/pb_win.go
+++ b/pb_win.go
@@ -124,6 +124,8 @@ func lockEcho() (shutdownCh chan struct{}, err error) {
 		err = fmt.Errorf("Can't set terminal settings: %v", e)
 		return
 	}
+
+	shutdownCh = make(chan struct{})
 	return
 }
 


### PR DESCRIPTION
This patch is intended for v1

I tried running the `example_multiple_test.go` file on a Windows 10 machine and got his output:

```
First  200 / 200 [================================================================================================================================================================================================] 100.00%
Second  200 / 200 [===========================================================================================================================================================================================] 100.00% 10s
Third  200 / 200 [============================================================================================================================================================================================] 100.00% 10s
panic: close of nil channel

goroutine 1 [running]:
gopkg.in/cheggaaa/pb%2ev1.(*Pool).Stop.func1()
        D:/code/go/src/gopkg.in/cheggaaa/pb.v1/pool.go:93 +0x35
sync.(*Once).Do(0xc04205c110, 0xc042089ec0)
        C:/go/src/sync/once.go:44 +0xc5
gopkg.in/cheggaaa/pb%2ev1.(*Pool).Stop(0xc04205c0c0, 0x5076b8, 0xc04200e100)
        D:/code/go/src/gopkg.in/cheggaaa/pb.v1/pool.go:92 +0x57
main.main()
        D:/code/go/src/example_multiple.go:36 +0x243
exit status 2
```