### PR TITLE
support for non-tty execution in pool_x.go and pb_x.go

### DIFF
--- a/pb_x.go
+++ b/pb_x.go
@@ -20,6 +20,7 @@ var (
 	echoLockMutex    sync.Mutex
 	origTermStatePtr *unix.Termios
 	tty              *os.File
+	istty            bool
 )
 
 func init() {
@@ -28,13 +29,18 @@ func init() {
 
 	var err error
 	tty, err = os.Open("/dev/tty")
+	istty = true
 	if err != nil {
 		tty = os.Stdin
+		istty = false
 	}
 }
 
 // terminalWidth returns width of the terminal.
 func terminalWidth() (int, error) {
+	if !istty {
+		return 0, errors.New("Not Supported")
+	}
 	echoLockMutex.Lock()
 	defer echoLockMutex.Unlock()
 
@@ -51,26 +57,28 @@ func terminalWidth() (int, error) {
 func lockEcho() (shutdownCh chan struct{}, err error) {
 	echoLockMutex.Lock()
 	defer echoLockMutex.Unlock()
-	if origTermStatePtr != nil {
-		return shutdownCh, ErrPoolWasStarted
+	if istty {
+		if origTermStatePtr != nil {
+			return shutdownCh, ErrPoolWasStarted
+		}
+
+		fd := int(tty.Fd())
+
+		origTermStatePtr, err = unix.IoctlGetTermios(fd, ioctlReadTermios)
+		if err != nil {
+			return nil, fmt.Errorf("Can't get terminal settings: %v", err)
+		}
+
+		oldTermios := *origTermStatePtr
+		newTermios := oldTermios
+		newTermios.Lflag &^= syscall.ECHO
+		newTermios.Lflag |= syscall.ICANON | syscall.ISIG
+		newTermios.Iflag |= syscall.ICRNL
+		if err := unix.IoctlSetTermios(fd, ioctlWriteTermios, &newTermios); err != nil {
+			return nil, fmt.Errorf("Can't set terminal settings: %v", err)
+		}
+
 	}
-
-	fd := int(tty.Fd())
-
-	origTermStatePtr, err = unix.IoctlGetTermios(fd, ioctlReadTermios)
-	if err != nil {
-		return nil, fmt.Errorf("Can't get terminal settings: %v", err)
-	}
-
-	oldTermios := *origTermStatePtr
-	newTermios := oldTermios
-	newTermios.Lflag &^= syscall.ECHO
-	newTermios.Lflag |= syscall.ICANON | syscall.ISIG
-	newTermios.Iflag |= syscall.ICRNL
-	if err := unix.IoctlSetTermios(fd, ioctlWriteTermios, &newTermios); err != nil {
-		return nil, fmt.Errorf("Can't set terminal settings: %v", err)
-	}
-
 	shutdownCh = make(chan struct{})
 	go catchTerminate(shutdownCh)
 	return
@@ -79,16 +87,18 @@ func lockEcho() (shutdownCh chan struct{}, err error) {
 func unlockEcho() error {
 	echoLockMutex.Lock()
 	defer echoLockMutex.Unlock()
-	if origTermStatePtr == nil {
-		return nil
+	if istty {
+		if origTermStatePtr == nil {
+			return nil
+		}
+
+		fd := int(tty.Fd())
+
+		if err := unix.IoctlSetTermios(fd, ioctlWriteTermios, origTermStatePtr); err != nil {
+			return fmt.Errorf("Can't set terminal settings: %v", err)
+		}
+
 	}
-
-	fd := int(tty.Fd())
-
-	if err := unix.IoctlSetTermios(fd, ioctlWriteTermios, origTermStatePtr); err != nil {
-		return fmt.Errorf("Can't set terminal settings: %v", err)
-	}
-
 	origTermStatePtr = nil
 
 	return nil

--- a/pool.go
+++ b/pool.go
@@ -90,7 +90,9 @@ func (p *Pool) writer() {
 // Restore terminal state and close pool
 func (p *Pool) Stop() error {
 	p.finishOnce.Do(func() {
-		close(p.shutdownCh)
+		if p.shutdownCh != nil {
+			close(p.shutdownCh)
+		}
 	})
 
 	// Wait for the worker to complete


### PR DESCRIPTION
I had issues using pb.v1 when running without tty (like as in a system service).