### PR TITLE
Fix build on WebAssembly/JS

### DIFF
--- a/pb_appengine.go
+++ b/pb_appengine.go
@@ -1,4 +1,4 @@
-// +build appengine
+// +build appengine js
 
 package pb
 

--- a/pb_x.go
+++ b/pb_x.go
@@ -1,5 +1,5 @@
 // +build linux darwin freebsd netbsd openbsd solaris dragonfly
-// +build !appengine
+// +build !appengine !js
 
 package pb
 


### PR DESCRIPTION
When compiling with `GOOS=js GOARCH=wasm`, the build fails because `terminalWidth()` is not implemented for this environment.

I added the `js` build target to the existing `terminalWidth()` stub (`pb_appengine.go`).