### PR TITLE
fix importing with go mod

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,62 +2,62 @@
 
 
 [[projects]]
-  name = "github.com/mattn/go-colorable"
+  digest = "1:9abfcff0d74d46ece54860fdf67c93d2bcbd0391dfb771d3f7fd7c38319fdc05"
+  name = "github.com/VividCortex/ewma"
   packages = ["."]
-  revision = "ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8"
-  version = "v0.0.6"
-
-[[projects]]
-  name = "github.com/mattn/go-isatty"
-  packages = ["."]
-  revision = "3a115632dcd687f9c8cd01679c83a06a0e21c1f3"
-  version = "v0.0.1"
-
-[[projects]]
-  branch = "master"
-  name = "golang.org/x/sys"
-  packages = ["unix"]
-  revision = "b90f89a1e7a9c1f6b918820b3daa7f08488c8594"
-
-[[projects]]
-  name = "gopkg.in/VividCortex/ewma.v1"
-  packages = ["."]
+  pruneopts = ""
   revision = "2f8aa9741ab4b5b80945c750b871131b88ef5b7f"
   version = "v1.0"
 
 [[projects]]
-  name = "gopkg.in/cheggaaa/pb.v2"
-  packages = ["termutil"]
-  revision = "180c76fdb3025713f501cd481e47810a9c715bd7"
-  version = "v2.0.1"
-
-[[projects]]
-  name = "gopkg.in/fatih/color.v1"
+  digest = "1:c9bebdae4ac52d0c3bbe5876de3d72f3bb05b4986865cdb3f15e305e1dc4fbca"
+  name = "github.com/fatih/color"
   packages = ["."]
+  pruneopts = ""
   revision = "570b54cabe6b8eb0bc2dfce68d964677d63b5260"
   version = "v1.5.0"
 
 [[projects]]
-  name = "gopkg.in/mattn/go-colorable.v0"
+  digest = "1:f6cb920ecbe2ff08c6efb87868e25727e25e9e0c7156cbab3b005d2462903078"
+  name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = ""
   revision = "d228849504861217f796da67fae4f6e347643f15"
   version = "v0.0.7"
 
 [[projects]]
-  name = "gopkg.in/mattn/go-isatty.v0"
+  digest = "1:420bb8eabfa6dff0cb5c8e786489a420e7e9d93a8b1d83882cce70c5a5b9bc3e"
+  name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = ""
   revision = "fc9e8d8ef48496124e79ae0df75490096eccf6fe"
   version = "v0.0.2"
 
 [[projects]]
-  name = "gopkg.in/mattn/go-runewidth.v0"
+  digest = "1:81e673df85e765593a863f67cba4544cf40e8919590f04d67664940786c2b61a"
+  name = "github.com/mattn/go-runewidth"
   packages = ["."]
+  pruneopts = ""
   revision = "9e777a8366cce605130a531d2cd6363d07ad7317"
   version = "v0.0.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:da4ca00789ba429a2d46fcccc07b5216d91111f6c8339379f80cebec239ce919"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  pruneopts = ""
+  revision = "b90f89a1e7a9c1f6b918820b3daa7f08488c8594"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cf10fbfc96962122f1a56c1752a1d5dab64799ffedc58460e1ab1465d2bef5e2"
+  input-imports = [
+    "github.com/VividCortex/ewma",
+    "github.com/fatih/color",
+    "github.com/mattn/go-colorable",
+    "github.com/mattn/go-isatty",
+    "github.com/mattn/go-runewidth",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -67,25 +67,25 @@
 
 
 [[constraint]]
-  name = "gopkg.in/VividCortex/ewma.v1"
+  name = "github.com/VividCortex/ewma"
   version = "1.0.0"
 
 [[constraint]]
-  name = "gopkg.in/cheggaaa/pb.v2"
+  name = "github.com/cheggaaa/pb"
   version = "2.0.1"
 
 [[constraint]]
-  name = "gopkg.in/fatih/color.v1"
+  name = "github.com/fatih/color"
   version = "1.5.0"
 
 [[constraint]]
-  name = "gopkg.in/mattn/go-colorable.v0"
+  name = "github.com/mattn/go-colorable"
   version = "0.0.7"
 
 [[constraint]]
-  name = "gopkg.in/mattn/go-isatty.v0"
+  name = "github.com/mattn/go-isatty"
   version = "0.0.2"
 
 [[constraint]]
-  name = "gopkg.in/mattn/go-runewidth.v0"
+  name = "github.com/mattn/go-runewidth"
   version = "0.0.2"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is proposal for the second version of progress bar
 ## Installation
 
 ```
-go get gopkg.in/cheggaaa/pb.v2
+go get github.com/cheggaaa/pb
 ```   
 
 ## Usage   
@@ -21,7 +21,7 @@ go get gopkg.in/cheggaaa/pb.v2
 package main
 
 import (
-	"gopkg.in/cheggaaa/pb.v2"
+	"github.com/cheggaaa/pb"
 	"time"
 )
 

--- a/element_test.go
+++ b/element_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/fatih/color.v1"
+	"github.com/fatih/color"
 )
 
 func testState(total, value int64, maxWidth int, bools ...bool) (s *State) {

--- a/pb.go
+++ b/pb.go
@@ -12,9 +12,9 @@ import (
 	"text/template"
 	"time"
 
-	"gopkg.in/cheggaaa/pb.v2/termutil"
-	"gopkg.in/mattn/go-colorable.v0"
-	"gopkg.in/mattn/go-isatty.v0"
+	"github.com/cheggaaa/pb/termutil"
+	"github.com/mattn/go-colorable"
+	"github.com/mattn/go-isatty"
 )
 
 // Version of ProgressBar library

--- a/pb_test.go
+++ b/pb_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/fatih/color.v1"
+	"github.com/fatih/color"
 )
 
 func TestPBBasic(t *testing.T) {

--- a/speed.go
+++ b/speed.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"time"
 
-	"gopkg.in/VividCortex/ewma.v1"
+	"github.com/VividCortex/ewma"
 )
 
 var speedAddLimit = time.Second / 2

--- a/template.go
+++ b/template.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"text/template"
 
-	"gopkg.in/fatih/color.v1"
+	"github.com/fatih/color"
 )
 
 // ProgressBarTemplate that template string

--- a/util.go
+++ b/util.go
@@ -3,7 +3,7 @@ package pb
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/mattn/go-runewidth.v0"
+	"github.com/mattn/go-runewidth"
 	"math"
 	"regexp"
 	//"unicode/utf8"

--- a/util_test.go
+++ b/util_test.go
@@ -1,7 +1,7 @@
 package pb
 
 import (
-	"gopkg.in/fatih/color.v1"
+	"github.com/fatih/color"
 	"testing"
 )
 


### PR DESCRIPTION
The repositories github.com/mattn/go-colorable and
github.com/mattn/go-isatty have moved to using go modules; using gopkg.in
to import them breaks:

https://github.com/golang/go/issues/30636

Let's use the real URLs with hashes.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>