### PR TITLE
add writer proxy

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -276,6 +276,13 @@ func (pb *ProgressBar) NewProxyReader(r io.Reader) *Reader {
 	return &Reader{r, pb}
 }
 
+// Create new proxy writer over bar
+// Takes io.Writer or io.WriteCloser
+func (pb *ProgressBar) NewProxyWriter(r io.Writer) *Writer {
+	return &Writer{r, pb}
+}
+
+
 func (pb *ProgressBar) write(total, current int64) {
 	pb.mu.Lock()
 	defer pb.mu.Unlock()

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,25 @@
+package pb
+
+import (
+	"io"
+)
+
+// It's proxy Writer, implement io.Writer
+type Writer struct {
+	io.Writer
+	bar *ProgressBar
+}
+
+func (r *Writer) Write(p []byte) (n int, err error) {
+	n, err = r.Writer.Write(p)
+	r.bar.Add(n)
+	return
+}
+
+// Close the reader when it implements io.Closer
+func (r *Writer) Close() (err error) {
+	if closer, ok := r.Writer.(io.Closer); ok {
+		return closer.Close()
+	}
+	return
+}


### PR DESCRIPTION
diffrent from reader proxy, writer proxy update the progress bar based on writing when os writes data. it is faster in some situation.  especially when read network data and save to the disk. this is due to the function io.copy.