### PR TITLE
Add 'reset' for more flexibility

### DIFF
--- a/v3/template.go
+++ b/v3/template.go
@@ -31,17 +31,17 @@ var templateCache = make(map[string]*template.Template)
 
 var defaultTemplateFuncs = template.FuncMap{
 	// colors
-	"black":    color.New(color.FgBlack).SprintFunc(),
-	"red":      color.New(color.FgRed).SprintFunc(),
-	"green":    color.New(color.FgGreen).SprintFunc(),
-	"yellow":   color.New(color.FgYellow).SprintFunc(),
-	"blue":     color.New(color.FgBlue).SprintFunc(),
-	"magenta":  color.New(color.FgMagenta).SprintFunc(),
-	"cyan":     color.New(color.FgCyan).SprintFunc(),
-	"white":    color.New(color.FgWhite).SprintFunc(),
-	"reset":    color.New(color.Reset).SprintFunc(),
-	"rndcolor": rndcolor,
-	"rnd":      rnd,
+	"black":      color.New(color.FgBlack).SprintFunc(),
+	"red":        color.New(color.FgRed).SprintFunc(),
+	"green":      color.New(color.FgGreen).SprintFunc(),
+	"yellow":     color.New(color.FgYellow).SprintFunc(),
+	"blue":       color.New(color.FgBlue).SprintFunc(),
+	"magenta":    color.New(color.FgMagenta).SprintFunc(),
+	"cyan":       color.New(color.FgCyan).SprintFunc(),
+	"white":      color.New(color.FgWhite).SprintFunc(),
+	"resetcolor": color.New(color.Reset).SprintFunc(),
+	"rndcolor":   rndcolor,
+	"rnd":        rnd,
 }
 
 func getTemplate(tmpl string) (t *template.Template, err error) {

--- a/v3/template.go
+++ b/v3/template.go
@@ -39,6 +39,7 @@ var defaultTemplateFuncs = template.FuncMap{
 	"magenta":  color.New(color.FgMagenta).SprintFunc(),
 	"cyan":     color.New(color.FgCyan).SprintFunc(),
 	"white":    color.New(color.FgWhite).SprintFunc(),
+	"reset":    color.New(color.Reset).SprintFunc(),
 	"rndcolor": rndcolor,
 	"rnd":      rnd,
 }


### PR DESCRIPTION
There are cases when the state transition from the bar being "started" to "finished" cause an over-application of the last set color in the bar.

For instance: 

```
`{{ blue "no reset" }} {{ counters . | red }} {{bar . "|" (green "█" ) ">" "-" "|"}} {{percent . }} {{speed .}} {{rtime .}}`
``` 

causes everything after `green` to be green. Once we add `reset` there's a slight improvement during the render, as the trailing elements are not green, but upon transition to the "finished" state, the rest of the line turns green:

```
`{{ blue "nested reset" }} {{ counters . | red }} {{bar . "|" (green "█" ) (reset ">") "-" "|"}} {{percent . }} {{speed .}} {{rtime .}}`
 ```

and finally, with an external reset:

```
`{{ blue "external reset" }} {{ counters . | red }} {{bar . "|" (green "█" ) ">" "-" "|"}} {{percent . | reset}} {{speed .}} {{rtime .}}`
```
which functions very similar to the way that terminal color resets work in shells.

There may be a better way to manage the state transition form "started" to "finished", but this does the trick.