### PR TITLE
Add SIBytesPrefix setting to use SI prefix names in v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,11 @@ bar.SetRefreshRate(time.Second)
 // force set io.Writer, by default it's os.Stderr
 bar.SetWriter(os.Stdout)
 
-// bar will format numbers as bytes (B, Kb, Mb, etc)
+// bar will format numbers as bytes (B, KiB, MiB, etc)
 bar.Set(pb.Byte, true)
+
+// bar use SI bytes prefix names (B, kB) instead of IEC (B, KiB)
+bar.Set(pb.SIBytesPrefix, true)
 
 // set custom bar template
 bar.SetTemplateString(myTemplate)

--- a/v3/element_test.go
+++ b/v3/element_test.go
@@ -97,7 +97,7 @@ func TestElementBar(t *testing.T) {
 
 	// unicode
 	f2 := []string{"⚑", ".", ">", "⟞", "⚐"}
-	testElementBarString(t, testState(100, 50, 10, false, true), ElementBar, "⚑..>⟞⟞⟞⚐", f2...)
+	testElementBarString(t, testState(100, 50, 8, false, true), ElementBar, "⚑..>⟞⟞⟞⚐", f2...)
 
 	// no adaptive
 	testElementBarString(t, testState(0, 50, 10), ElementBar, "[____________________________]")

--- a/v3/pb.go
+++ b/v3/pb.go
@@ -28,6 +28,9 @@ const (
 	// bar.Set(pb.Bytes, true)
 	Bytes key = 1 << iota
 
+	// Use SI bytes prefix names (kB, MB, etc) instead of IEC prefix names (KiB, MiB, etc)
+	SIBytesPrefix
+
 	// Terminal means we're will print to terminal and can use ascii sequences
 	// Also we're will try to use terminal width
 	Terminal
@@ -351,7 +354,7 @@ func (pb *ProgressBar) StartTime() time.Time {
 // Format convert int64 to string according to the current settings
 func (pb *ProgressBar) Format(v int64) string {
 	if pb.GetBool(Bytes) {
-		return formatBytes(v)
+		return formatBytes(v, pb.GetBool(SIBytesPrefix))
 	}
 	return strconv.FormatInt(v, 10)
 }

--- a/v3/util.go
+++ b/v3/util.go
@@ -14,6 +14,11 @@ const (
 	_MiB = 1048576
 	_GiB = 1073741824
 	_TiB = 1099511627776
+
+	_kB = 1e3
+	_MB = 1e6
+	_GB = 1e9
+	_TB = 1e12
 )
 
 var ctrlFinder = regexp.MustCompile("\x1b\x5b[0-9]+\x6d")
@@ -76,19 +81,35 @@ func round(val float64) (newVal float64) {
 	return
 }
 
-// Convert bytes to human readable string. Like a 2 MiB, 64.2 KiB, 52 B
-func formatBytes(i int64) (result string) {
-	switch {
-	case i >= _TiB:
-		result = fmt.Sprintf("%.02f TiB", float64(i)/_TiB)
-	case i >= _GiB:
-		result = fmt.Sprintf("%.02f GiB", float64(i)/_GiB)
-	case i >= _MiB:
-		result = fmt.Sprintf("%.02f MiB", float64(i)/_MiB)
-	case i >= _KiB:
-		result = fmt.Sprintf("%.02f KiB", float64(i)/_KiB)
-	default:
-		result = fmt.Sprintf("%d B", i)
+// Convert bytes to human readable string. Like a 2 MiB, 64.2 KiB, or 2 MB, 64.2 kB
+// if useSIPrefix is set to true
+func formatBytes(i int64, useSIPrefix bool) (result string) {
+	if !useSIPrefix {
+		switch {
+		case i >= _TiB:
+			result = fmt.Sprintf("%.02f TiB", float64(i)/_TiB)
+		case i >= _GiB:
+			result = fmt.Sprintf("%.02f GiB", float64(i)/_GiB)
+		case i >= _MiB:
+			result = fmt.Sprintf("%.02f MiB", float64(i)/_MiB)
+		case i >= _KiB:
+			result = fmt.Sprintf("%.02f KiB", float64(i)/_KiB)
+		default:
+			result = fmt.Sprintf("%d B", i)
+		}
+	} else {
+		switch {
+		case i >= _TB:
+			result = fmt.Sprintf("%.02f TB", float64(i)/_TB)
+		case i >= _GB:
+			result = fmt.Sprintf("%.02f GB", float64(i)/_GB)
+		case i >= _MB:
+			result = fmt.Sprintf("%.02f MB", float64(i)/_MB)
+		case i >= _kB:
+			result = fmt.Sprintf("%.02f kB", float64(i)/_kB)
+		default:
+			result = fmt.Sprintf("%d B", i)
+		}
 	}
 	return
 }

--- a/v3/util_test.go
+++ b/v3/util_test.go
@@ -48,17 +48,24 @@ func TestUtilRound(t *testing.T) {
 func TestUtilFormatBytes(t *testing.T) {
 	inputs := []struct {
 		v int64
+		s bool
 		e string
 	}{
-		{v: 1000, e: "1000 B"},
-		{v: 1024, e: "1.00 KiB"},
-		{v: 3*_MiB + 140*_KiB, e: "3.14 MiB"},
-		{v: 2 * _GiB, e: "2.00 GiB"},
-		{v: 2048 * _GiB, e: "2.00 TiB"},
+		{v: 1000, s: false, e: "1000 B"},
+		{v: 1024, s: false, e: "1.00 KiB"},
+		{v: 3*_MiB + 140*_KiB, s: false, e: "3.14 MiB"},
+		{v: 2 * _GiB, s: false, e: "2.00 GiB"},
+		{v: 2048 * _GiB, s: false, e: "2.00 TiB"},
+
+		{v: 999, s: true, e: "999 B"},
+		{v: 1024, s: true, e: "1.02 kB"},
+		{v: 3*_MB + 140*_kB, s: true, e: "3.14 MB"},
+		{v: 2 * _GB, s: true, e: "2.00 GB"},
+		{v: 2048 * _GB, s: true, e: "2.05 TB"},
 	}
 
 	for _, input := range inputs {
-		actual := formatBytes(input.v)
+		actual := formatBytes(input.v, input.s)
 		if actual != input.e {
 			t.Errorf("Expected {%s} was {%s}", input.e, actual)
 		}


### PR DESCRIPTION
This was added in https://github.com/cheggaaa/pb/pull/111 on v1.
So I added it on v3.
Not sure about naming too.