### PR TITLE
add ProgressBar.AddTotal

### DIFF
--- a/v3/pb.go
+++ b/v3/pb.go
@@ -238,6 +238,12 @@ func (pb *ProgressBar) SetTotal(value int64) *ProgressBar {
 	return pb
 }
 
+// AddTotal adds to the total bar value
+func (pb *ProgressBar) AddTotal(value int64) *ProgressBar {
+	atomic.AddInt64(&pb.total, value)
+	return pb
+}
+
 // SetCurrent sets the current bar value
 func (pb *ProgressBar) SetCurrent(value int64) *ProgressBar {
 	atomic.StoreInt64(&pb.current, value)

--- a/v3/pb_test.go
+++ b/v3/pb_test.go
@@ -94,6 +94,21 @@ func TestPBMaxWidth(t *testing.T) {
 	}
 }
 
+func TestAddTotal(t *testing.T) {
+	bar := new(ProgressBar)
+	bar.SetTotal(0)
+	bar.AddTotal(50)
+	got := bar.Total()
+	if got != 50 {
+		t.Errorf("bar.Total() = %v, want %v", got, 50)
+	}
+	bar.AddTotal(-10)
+	got = bar.Total()
+	if got != 40 {
+		t.Errorf("bar.Total() = %v, want %v", got, 40)
+	}
+}
+
 func TestPBTemplate(t *testing.T) {
 	bar := new(ProgressBar)
 	result := bar.SetTotal(100).SetCurrent(50).SetWidth(40).String()


### PR DESCRIPTION
This method is useful when you are iteratively determining your total work. For example, [my use case](https://github.com/kevin-hanselman/dud/blob/f5af8727fdd3ea437798129083d4218ac1c2490d/src/cache/commit.go#L94) is walking a file tree and processing files. Without this method, I would need to gather all of the files before starting the progress bar.