### PR TITLE
Reduce resolution for elapsed time > 1s

### DIFF
--- a/v3/element.go
+++ b/v3/element.go
@@ -232,7 +232,11 @@ var ElementBar ElementFunc = func(state *State, args ...string) string {
 }
 
 func elapsedTime(state *State) time.Duration {
-	return state.Time().Sub(state.StartTime()).Truncate(time.Millisecond)
+	delta := state.Time().Sub(state.StartTime())
+	if delta < time.Second {
+		return delta.Truncate(time.Millisecond)
+	}
+	return delta.Truncate(time.Second)
 }
 
 // ElementRemainingTime calculates remaining time based on speed (EWMA)


### PR DESCRIPTION
#177 increased the resolution shown on elapsed time from seconds to milliseconds. This applied regardless of the total duration, so even if the duration was large, a high resolution would be displayed, such as "897.213s". This patch changes the behavior so that milliseconds are only shown if the total time is less than a second, so that example would be displayed as "897s" instead.