### PR TITLE
Add parameter to specify elapsed time precision

### DIFF
--- a/v3/element.go
+++ b/v3/element.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"strings"
 	"sync"
 	"time"
 )
@@ -231,13 +232,46 @@ var ElementBar ElementFunc = func(state *State, args ...string) string {
 	return p.buf.String()
 }
 
-func elapsedTime(state *State) time.Duration {
+func elapsedTime(state *State) string {
+	elapsed := state.Time().Sub(state.StartTime())
 	var precision time.Duration
 	var ok bool
 	if precision, ok = state.Get(TimeRound).(time.Duration); !ok {
-		precision = time.Second
+		// default behavior: round to nearest .1s when elapsed < 10s
+		//
+		// we compare with 9.95s as opposed to 10s to avoid an annoying
+		// interaction with the fixed precision display code below,
+		// where 9.9s would be rounded to 10s but printed as 10.0s, and
+		// then 10.0s would be rounded to 10s and printed as 10s
+		if elapsed < 9950*time.Millisecond {
+			precision = 100 * time.Millisecond
+		} else {
+			precision = time.Second
+		}
 	}
-	return state.Time().Sub(state.StartTime()).Round(precision)
+	rounded := elapsed.Round(precision)
+	if precision < time.Second && rounded >= time.Second {
+		// special handling to ensure string is shown with the given
+		// precision, with trailing zeros after the decimal point if
+		// necessary
+		reference := (2*time.Second - time.Nanosecond).Truncate(precision).String()
+		// reference looks like "1.9[...]9s", telling us how many
+		// decimal digits we need
+		neededDecimals := len(reference) - 3
+		s := rounded.String()
+		dotIndex := strings.LastIndex(s, ".")
+		if dotIndex != -1 {
+			// s has the form "[stuff].[decimals]s"
+			decimals := len(s) - dotIndex - 2
+			extraZeros := neededDecimals - decimals
+			return fmt.Sprintf("%s%ss", s[:len(s)-1], strings.Repeat("0", extraZeros))
+		} else {
+			// s has the form "[stuff]s"
+			return fmt.Sprintf("%s.%ss", s[:len(s)-1], strings.Repeat("0", neededDecimals))
+		}
+	} else {
+		return rounded.String()
+	}
 }
 
 // ElementRemainingTime calculates remaining time based on speed (EWMA)
@@ -260,7 +294,7 @@ var ElementRemainingTime ElementFunc = func(state *State, args ...string) string
 }
 
 // ElementElapsedTime shows elapsed time
-// Optionally cat take one argument - it's format for time string.
+// Optionally can take one argument - it's format for time string.
 // In template use as follows: {{etime .}} or {{etime . "%s elapsed"}}
 var ElementElapsedTime ElementFunc = func(state *State, args ...string) string {
 	return fmt.Sprintf(argsHelper(args).getOr(0, "%s"), elapsedTime(state))

--- a/v3/element.go
+++ b/v3/element.go
@@ -232,7 +232,12 @@ var ElementBar ElementFunc = func(state *State, args ...string) string {
 }
 
 func elapsedTime(state *State) time.Duration {
-	return state.Time().Sub(state.StartTime()).Truncate(time.Millisecond)
+	var precision time.Duration
+	var ok bool
+	if precision, ok = state.Get(TimeRound).(time.Duration); !ok {
+		precision = time.Second
+	}
+	return state.Time().Sub(state.StartTime()).Round(precision)
 }
 
 // ElementRemainingTime calculates remaining time based on speed (EWMA)

--- a/v3/pb.go
+++ b/v3/pb.go
@@ -48,6 +48,9 @@ const (
 
 	// Hide the progress bar when finished, rather than leaving it up. By default it's false.
 	CleanOnFinish
+
+	// Round elapsed time to this precision. Defaults to time.Second.
+	TimeRound
 )
 
 const (


### PR DESCRIPTION
db60ccefe5cb616c2f8a1bde35ee059118dce62a (released in v3.0.7) increased the resolution shown on elapsed time from seconds to milliseconds. The behavior prior to v3.0.7 was to truncate the time to the nearest second. This patch allows the user to control the precision. The default is to round to the nearest second, like the pre-v3.0.7 behavior. This patch also switches from truncation to rounding.

This is an alternative to #180, as suggested in https://github.com/cheggaaa/pb/pull/180#issuecomment-813383854.