### PR TITLE
Add support for zOS

### DIFF
--- a/pb_x.go
+++ b/pb_x.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd netbsd openbsd solaris dragonfly aix
+// +build linux darwin freebsd netbsd openbsd solaris dragonfly aix zos
 // +build !appengine !js
 
 package pb

--- a/pool.go
+++ b/pool.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd netbsd openbsd solaris dragonfly windows plan9 aix
+// +build linux darwin freebsd netbsd openbsd solaris dragonfly windows plan9 aix zos
 
 package pb
 

--- a/pool_x.go
+++ b/pool_x.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd netbsd openbsd solaris dragonfly plan9 aix
+// +build linux darwin freebsd netbsd openbsd solaris dragonfly plan9 aix zos
 
 package pb
 

--- a/termios_sysv.go
+++ b/termios_sysv.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build linux solaris aix
+// +build linux solaris aix zos
 // +build !appengine
 
 package pb


### PR DESCRIPTION
By adding `zos` build tags to the appropriate files, the package can now support zOS