### PR TITLE
Add a white space after prefix and before suffix

### DIFF
--- a/v3/preset.go
+++ b/v3/preset.go
@@ -3,13 +3,13 @@ package pb
 var (
 	// Full - preset with all default available elements
 	// Example: 'Prefix 20/100 [-->______] 20% 1 p/s ETA 1m Suffix'
-	Full ProgressBarTemplate = `{{string . "prefix"}}{{counters . }} {{bar . }} {{percent . }} {{speed . }} {{rtime . "ETA %s"}}{{string . "suffix"}}`
+	Full ProgressBarTemplate = `{{with string . "prefix"}}{{.}} {{end}}{{counters . }} {{bar . }} {{percent . }} {{speed . }} {{rtime . "ETA %s"}}{{with string . "suffix"}} {{.}}{{end}}`
 
 	// Default - preset like Full but without elapsed time
-	// Example: 'Prefix 20/100 [-->______] 20% 1 p/s ETA 1m Suffix'
-	Default ProgressBarTemplate = `{{string . "prefix"}}{{counters . }} {{bar . }} {{percent . }} {{speed . }}{{string . "suffix"}}`
+	// Example: 'Prefix 20/100 [-->______] 20% 1 p/s Suffix'
+	Default ProgressBarTemplate = `{{with string . "prefix"}}{{.}} {{end}}{{counters . }} {{bar . }} {{percent . }} {{speed . }}{{with string . "suffix"}} {{.}}{{end}}`
 
 	// Simple - preset without speed and any timers. Only counters, bar and percents
 	// Example: 'Prefix 20/100 [-->______] 20% Suffix'
-	Simple ProgressBarTemplate = `{{string . "prefix"}}{{counters . }} {{bar . }} {{percent . }}{{string . "suffix"}}`
+	Simple ProgressBarTemplate = `{{with string . "prefix"}}{{.}} {{end}}{{counters . }} {{bar . }} {{percent . }}{{with string . "suffix"}} {{.}}{{end}}`
 )

--- a/v3/preset_test.go
+++ b/v3/preset_test.go
@@ -1,0 +1,29 @@
+package pb
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPreset(t *testing.T) {
+	prefix := "Prefix"
+	suffix := "Suffix"
+
+	for _, preset := range []ProgressBarTemplate{Full, Default, Simple} {
+		bar := preset.New(100).
+			SetCurrent(20).
+			Set("prefix", prefix).
+			Set("suffix", suffix).
+			SetWidth(50)
+
+		// initialize the internal state
+		_, _ = bar.render()
+		s := bar.String()
+		if !strings.HasPrefix(s, prefix+" ") {
+			t.Error("prefix not found:", s)
+		}
+		if !strings.HasSuffix(s, " "+suffix) {
+			t.Error("suffix not found:", s)
+		}
+	}
+}


### PR DESCRIPTION
Current preset templates render prefix and suffix without a white space like this:
```
// Simple template
Prefix20 / 100 [--->________________] 20.00%Suffix
```
But, it'd be nice if there is a space like this:
```
Prefix 20 / 100 [--->______________] 20.00% Suffix
```

This PR modifies those templates so that it checks if prefix and/or suffix are given and add white space to them.