### PR TITLE
windows print: enable virtual terminal processing

### DIFF
--- a/v3/termutil/term_win.go
+++ b/v3/termutil/term_win.go
@@ -138,9 +138,8 @@ func lockEcho() (err error) {
 	}
 
 	newState := oldState
-	const ENABLE_ECHO_INPUT = 0x0004
 	const ENABLE_LINE_INPUT = 0x0002
-	newState = newState & (^(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT))
+	newState = newState & (^ENABLE_LINE_INPUT)
 	if _, _, e := syscall.Syscall(setConsoleMode.Addr(), 2, uintptr(syscall.Stdout), uintptr(newState), 0); e != 0 {
 		err = fmt.Errorf("Can't set terminal settings: %v", e)
 		return


### PR DESCRIPTION
Disabling `ENABLE_ECHO_INPUT` during `SetConsoleMode`  is causing issues rendering color on windows terminals as the same address is being used to `ENABLE_VIRTUAL_TERMINAL_PROCESSING` which is required for parsing colors.

Docs for reference: https://learn.microsoft.com/en-us/windows/console/setconsolemode
