### PR TITLE
fix DIVISION_BY_ZERO.EX in pb

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -380,17 +380,21 @@ func (pb *ProgressBar) write(total, current int64) {
 				}
 
 				cursorLen := escapeAwareRuneCountInString(pb.Current)
-				if emptySize <= 0 {
-					barBox += strings.Repeat(pb.Current, curSize/cursorLen)
-				} else if curSize > 0 {
-					cursorEndLen := escapeAwareRuneCountInString(pb.CurrentN)
-					cursorRepetitions := (curSize - cursorEndLen) / cursorLen
-					barBox += strings.Repeat(pb.Current, cursorRepetitions)
-					barBox += pb.CurrentN
+				if cursorLen != 0 {
+					if emptySize <= 0 {
+						barBox += strings.Repeat(pb.Current, curSize/cursorLen)
+					} else if curSize > 0 {
+						cursorEndLen := escapeAwareRuneCountInString(pb.CurrentN)
+						cursorRepetitions := (curSize - cursorEndLen) / cursorLen
+						barBox += strings.Repeat(pb.Current, cursorRepetitions)
+						barBox += pb.CurrentN
+					}
 				}
 
 				emptyLen := escapeAwareRuneCountInString(pb.Empty)
-				barBox += strings.Repeat(pb.Empty, emptySize/emptyLen)
+				if emptyLen != 0 {
+					barBox += strings.Repeat(pb.Empty, emptySize/emptyLen)
+				}
 				barBox += pb.BarEnd
 			} else {
 				pos := size - int(current)%int(size)


### PR DESCRIPTION
Found by the static analyzer Svace (ISP RAS): DIVISION_BY_ZERO.EX.

Variable cursorLen, whose possible value set allows a zero value at pb.go:368 by calling function 'gopkg.in/cheggaaa/pb.v1.escapeAwareRuneCountInString', is used as a denominator at pb.go:370.

Variable cursorLen, whose possible value set allows a zero value at pb.go:368 by calling function 'gopkg.in/cheggaaa/pb.v1.escapeAwareRuneCountInString', is used as a denominator at pb.go:373.

Variable emptyLen, whose possible value set allows a zero value at pb.go:378 by calling function 'gopkg.in/cheggaaa/pb.v1.escapeAwareRuneCountInString', is used as a denominator at pb.go:379.