### PR TITLE
Add FiraCode progress bars glyphs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Rendering based on builtin [text/template](https://pkg.go.dev/text/template) pac
 All available elements are described in the [element.go](v3/element.go) file.
 The `bar` element accepts five standard parts: left border, fill, current, empty, and right border. It also accepts optional sixth and seventh parts for the empty left border and finished right border.
 
-Set `UNICODE_PROGRESS_BAR=true` to use the built-in Unicode progress bar glyphs for bars that use the implicit default template when the active terminal font supports them.
+Set `UNICODE_PROGRESS_BAR=true` to use the built-in Unicode progress bar glyphs for bars that use the default bar elements when the active terminal font supports them.
 
 #### All in one example:
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ func main() {
 Rendering based on builtin [text/template](https://pkg.go.dev/text/template) package. You can use existing pb's elements or create you own.
 
 All available elements are described in the [element.go](v3/element.go) file.
+The `bar` element accepts five standard parts: left border, fill, current, empty, and right border. It also accepts optional sixth and seventh parts for the empty left border and finished right border.
+
+Set `UNICODE_PROGRESS_BAR=true` to use the built-in Unicode progress bar glyphs for bars that use the implicit default template when the active terminal font supports them.
 
 #### All in one example:
 

--- a/v3/element.go
+++ b/v3/element.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -15,8 +16,22 @@ const (
 )
 
 var (
-	defaultBarEls = [barElementCount]string{"[", "-", ">", "_", "]", "", ""}
+	asciiBarEls   = [barElementCount]string{"[", "-", ">", "_", "]", "", ""}
+	firaBarEls    = [barElementCount]string{"", "", "", "", "", "", ""}
+	defaultBarEls = asciiBarEls
 )
+
+func init() {
+	configureDefaultBarEls()
+}
+
+func configureDefaultBarEls() {
+	defaultBarEls = asciiBarEls
+	if os.Getenv(unicodeProgressBarEnv) == "true" {
+		// Only "true" is accepted; values like "1" are ignored to match the Fira Code README spec.
+		defaultBarEls = firaBarEls
+	}
+}
 
 const (
 	barLeft = iota
@@ -164,7 +179,7 @@ func getProgressObj(state *State, args ...string) (p *bar) {
 		arg := argsH.getNotEmptyOr(i, defaultBarEls[i])
 		enabled := true
 		if i >= barLeftEmpty {
-			arg = argsH.getOr(i, "")
+			arg = argsH.getOr(i, defaultBarEls[i])
 			enabled = arg != ""
 		}
 		if p.enabled[i] != enabled {

--- a/v3/element.go
+++ b/v3/element.go
@@ -176,10 +176,19 @@ func getProgressObj(state *State, args ...string) (p *bar) {
 	}
 	argsH := argsHelper(args)
 	for i := range p.eb {
-		arg := argsH.getNotEmptyOr(i, defaultBarEls[i])
 		enabled := true
+
+		var arg string
+		switch {
+		case i < barLeftEmpty:
+			arg = argsH.getNotEmptyOr(i, defaultBarEls[i])
+		case len(args) == 0:
+			arg = defaultBarEls[i]
+		default:
+			arg = argsH.getOr(i, "")
+		}
+
 		if i >= barLeftEmpty {
-			arg = argsH.getOr(i, defaultBarEls[i])
 			enabled = arg != ""
 		}
 		if p.enabled[i] != enabled {

--- a/v3/element.go
+++ b/v3/element.go
@@ -15,7 +15,18 @@ const (
 )
 
 var (
-	defaultBarEls = [5]string{"[", "-", ">", "_", "]"}
+	defaultBarEls = [barElementCount]string{"[", "-", ">", "_", "]", "", ""}
+)
+
+const (
+	barLeft = iota
+	barFill
+	barCurrent
+	barEmpty
+	barRight
+	barLeftEmpty
+	barRightFinished
+	barElementCount
 )
 
 // Element is an interface for bar elements
@@ -122,9 +133,10 @@ const (
 )
 
 type bar struct {
-	eb  [5][]byte // elements in bytes
-	cc  [5]int    // cell counts
-	buf *bytes.Buffer
+	eb      [barElementCount][]byte // elements in bytes
+	cc      [barElementCount]int    // cell counts
+	enabled [barElementCount]bool
+	buf     *bytes.Buffer
 }
 
 func (p *bar) write(state *State, eln, width int) int {
@@ -150,6 +162,19 @@ func getProgressObj(state *State, args ...string) (p *bar) {
 	argsH := argsHelper(args)
 	for i := range p.eb {
 		arg := argsH.getNotEmptyOr(i, defaultBarEls[i])
+		enabled := true
+		if i >= barLeftEmpty {
+			arg = argsH.getOr(i, "")
+			enabled = arg != ""
+		}
+		if p.enabled[i] != enabled {
+			p.enabled[i] = enabled
+			p.eb[i] = nil
+			p.cc[i] = 0
+		}
+		if !enabled {
+			continue
+		}
 		if string(p.eb[i]) != arg {
 			p.cc[i] = CellCount(arg)
 			p.eb[i] = []byte(arg)
@@ -163,7 +188,11 @@ func getProgressObj(state *State, args ...string) (p *bar) {
 }
 
 // ElementBar make progress bar view [-->__]
-// Optionally can take up to 5 string arguments. Defaults is "[", "-", ">", "_", "]"
+// Optionally can take up to 7 string arguments.
+// Defaults is "[", "-", ">", "_", "]".
+// First five arguments are left border, fill, current, empty, and right border.
+// Sixth argument overrides the left border when progress is empty.
+// Seventh argument overrides the right border when progress is finished.
 // In template use as follows: {{bar . }} or {{bar . "<" "oOo" "|" "~" ">"}}
 // Color args: {{bar . (red "[") (green "-") ...
 var ElementBar ElementFunc = func(state *State, args ...string) string {
@@ -190,20 +219,28 @@ var ElementBar ElementFunc = func(state *State, args ...string) string {
 		widthLeft = 30
 	}
 
+	leftEl, rightEl := barLeft, barRight
+	if (total <= 0 || value == 0) && p.enabled[barLeftEmpty] {
+		leftEl = barLeftEmpty
+	}
+	if total == value && state.IsFinished() && p.enabled[barRightFinished] {
+		rightEl = barRightFinished
+	}
+
 	// write left border
-	if p.cc[0] < widthLeft {
-		widthLeft -= p.write(state, 0, p.cc[0])
+	if p.cc[leftEl] < widthLeft {
+		widthLeft -= p.write(state, leftEl, p.cc[leftEl])
 	} else {
-		p.write(state, 0, widthLeft)
+		p.write(state, leftEl, widthLeft)
 		return p.buf.String()
 	}
 
 	// check right border size
-	if p.cc[4] < widthLeft {
+	if p.cc[rightEl] < widthLeft {
 		// write later
-		widthLeft -= p.cc[4]
+		widthLeft -= p.cc[rightEl]
 	} else {
-		p.write(state, 4, widthLeft)
+		p.write(state, rightEl, widthLeft)
 		return p.buf.String()
 	}
 
@@ -216,18 +253,18 @@ var ElementBar ElementFunc = func(state *State, args ...string) string {
 
 	// write bar
 	if total == value && state.IsFinished() {
-		widthLeft -= p.write(state, 1, curCount)
-	} else if toWrite := curCount - p.cc[2]; toWrite > 0 {
-		widthLeft -= p.write(state, 1, toWrite)
-		widthLeft -= p.write(state, 2, p.cc[2])
+		widthLeft -= p.write(state, barFill, curCount)
+	} else if toWrite := curCount - p.cc[barCurrent]; toWrite > 0 {
+		widthLeft -= p.write(state, barFill, toWrite)
+		widthLeft -= p.write(state, barCurrent, p.cc[barCurrent])
 	} else if curCount > 0 {
-		widthLeft -= p.write(state, 2, curCount)
+		widthLeft -= p.write(state, barCurrent, curCount)
 	}
 	if widthLeft > 0 {
-		widthLeft -= p.write(state, 3, widthLeft)
+		widthLeft -= p.write(state, barEmpty, widthLeft)
 	}
 	// write right border
-	p.write(state, 4, p.cc[4])
+	p.write(state, rightEl, p.cc[rightEl])
 	// cut result and return string
 	return p.buf.String()
 }

--- a/v3/element_test.go
+++ b/v3/element_test.go
@@ -129,6 +129,17 @@ func TestElementBar(t *testing.T) {
 	}
 }
 
+func TestElementBarBorderOverrides(t *testing.T) {
+	format := []string{"L", "=", "=", ".", "R", "l", "F"}
+
+	testElementBarString(t, testState(100, 0, 7, false, true), ElementBar, "l.....R", format...)
+	testElementBarString(t, testState(100, 50, 7, false, true), ElementBar, "L===..R", format...)
+
+	st := testState(100, 100, 7, false, true)
+	st.finished = true
+	testElementBarString(t, st, ElementBar, "L=====F", format...)
+}
+
 func TestElementSpeed(t *testing.T) {
 	var state = testState(1000, 0, 0, false)
 	state.time = time.Now()

--- a/v3/pb.go
+++ b/v3/pb.go
@@ -23,6 +23,8 @@ import (
 // Version of ProgressBar library
 const Version = "3.0.8"
 
+const unicodeProgressBarEnv = "UNICODE_PROGRESS_BAR"
+
 type key int
 
 const (
@@ -123,7 +125,11 @@ func (pb *ProgressBar) configure() {
 	}
 
 	if pb.tmpl == nil {
-		pb.tmpl, pb.err = getTemplate(string(Default))
+		tmpl := Default
+		if unicodeProgressBarEnabled() {
+			tmpl = unicodeDefault
+		}
+		pb.tmpl, pb.err = getTemplate(string(tmpl))
 		if pb.err != nil {
 			return
 		}
@@ -157,6 +163,10 @@ func (pb *ProgressBar) configure() {
 		pb.coutput = pb.output
 	}
 	pb.nocoutput = colorable.NewNonColorable(pb.output)
+}
+
+func unicodeProgressBarEnabled() bool {
+	return os.Getenv(unicodeProgressBarEnv) == "true"
 }
 
 // Start starts the bar

--- a/v3/pb.go
+++ b/v3/pb.go
@@ -125,11 +125,7 @@ func (pb *ProgressBar) configure() {
 	}
 
 	if pb.tmpl == nil {
-		tmpl := Default
-		if unicodeProgressBarEnabled() {
-			tmpl = unicodeDefault
-		}
-		pb.tmpl, pb.err = getTemplate(string(tmpl))
+		pb.tmpl, pb.err = getTemplate(string(Default))
 		if pb.err != nil {
 			return
 		}
@@ -163,10 +159,6 @@ func (pb *ProgressBar) configure() {
 		pb.coutput = pb.output
 	}
 	pb.nocoutput = colorable.NewNonColorable(pb.output)
-}
-
-func unicodeProgressBarEnabled() bool {
-	return os.Getenv(unicodeProgressBarEnv) == "true"
 }
 
 // Start starts the bar

--- a/v3/pb_test.go
+++ b/v3/pb_test.go
@@ -111,7 +111,7 @@ func TestAddTotal(t *testing.T) {
 }
 
 func TestPBTemplate(t *testing.T) {
-	defer setEnv(unicodeProgressBarEnv, "false")()
+	defer setUnicodeProgressBarEnv("false")()
 
 	bar := new(ProgressBar)
 	result := bar.SetTotal(100).SetCurrent(50).SetWidth(40).String()
@@ -151,30 +151,43 @@ func TestPBTemplate(t *testing.T) {
 	}
 }
 
-func TestUnicodeProgressBarEnvUsesUnicodeDefault(t *testing.T) {
-	defer setEnv(unicodeProgressBarEnv, "true")()
+func TestUnicodeProgressBarEnvUsesFiraDefaultBarElements(t *testing.T) {
+	defer setUnicodeProgressBarEnv("true")()
 
-	result := New(100).SetCurrent(0).SetWidth(60).String()
-	if !strings.Contains(result, "") {
-		t.Errorf("unicode default must use empty left border: %q", result)
-	}
-	if !strings.Contains(result, "") {
-		t.Errorf("unicode default must use empty right border: %q", result)
-	}
-	if strings.Contains(result, "") {
-		t.Errorf("unicode default must not include spinner: %q", result)
+	for name, tmpl := range map[string]ProgressBarTemplate{
+		"Full":    Full,
+		"Default": Default,
+		"Simple":  Simple,
+		"Custom":  `{{bar . }}`,
+	} {
+		result := tmpl.New(100).SetCurrent(0).SetWidth(60).String()
+		if !strings.Contains(result, "") {
+			t.Errorf("%s must use fira empty left border: %q", name, result)
+		}
+		if !strings.Contains(result, "") {
+			t.Errorf("%s must use fira right border: %q", name, result)
+		}
 	}
 }
 
-func TestUnicodeProgressBarEnvDoesNotOverrideExplicitTemplate(t *testing.T) {
-	defer setEnv(unicodeProgressBarEnv, "true")()
+func TestUnicodeProgressBarEnvIgnoresOne(t *testing.T) {
+	defer setUnicodeProgressBarEnv("1")()
 
-	result := New(100).SetCurrent(0).SetWidth(60).SetTemplate(Default).String()
-	if !strings.Contains(result, "[") {
-		t.Errorf("explicit template must keep default left border: %q", result)
+	result := ProgressBarTemplate(`{{bar . }}`).New(100).SetCurrent(0).SetWidth(10).String()
+	if result != "[________]" {
+		t.Errorf("UNICODE_PROGRESS_BAR=1 must keep ascii defaults: %q", result)
 	}
+}
+
+func TestUnicodeProgressBarEnvDoesNotOverrideExplicitBarArgs(t *testing.T) {
+	defer setUnicodeProgressBarEnv("true")()
+
+	result := ProgressBarTemplate(`{{bar . "<" "=" ">" "." ">" "" ""}}`).New(100).SetCurrent(0).SetWidth(10).String()
 	if strings.Contains(result, "") {
-		t.Errorf("explicit template must not use unicode default: %q", result)
+		t.Errorf("explicit bar args must not use fira defaults: %q", result)
+	}
+	if !strings.Contains(result, "<") {
+		t.Errorf("explicit bar args must be used: %q", result)
 	}
 }
 
@@ -272,6 +285,17 @@ func setEnv(key, value string) func() {
 			return
 		}
 		os.Unsetenv(key)
+	}
+}
+
+func setUnicodeProgressBarEnv(value string) func() {
+	restoreEnv := setEnv(unicodeProgressBarEnv, value)
+	oldDefaultBarEls := defaultBarEls
+	configureDefaultBarEls()
+
+	return func() {
+		defaultBarEls = oldDefaultBarEls
+		restoreEnv()
 	}
 }
 

--- a/v3/pb_test.go
+++ b/v3/pb_test.go
@@ -182,12 +182,44 @@ func TestUnicodeProgressBarEnvIgnoresOne(t *testing.T) {
 func TestUnicodeProgressBarEnvDoesNotOverrideExplicitBarArgs(t *testing.T) {
 	defer setUnicodeProgressBarEnv("true")()
 
-	result := ProgressBarTemplate(`{{bar . "<" "=" ">" "." ">" "" ""}}`).New(100).SetCurrent(0).SetWidth(10).String()
-	if strings.Contains(result, "") {
-		t.Errorf("explicit bar args must not use fira defaults: %q", result)
-	}
-	if !strings.Contains(result, "<") {
-		t.Errorf("explicit bar args must be used: %q", result)
+	for _, test := range []struct {
+		name     string
+		template ProgressBarTemplate
+		current  int64
+		finished bool
+		expected string
+	}{
+		{
+			name:     "five args empty",
+			template: `{{bar . "<" "=" ">" "." ">"}}`,
+			current:  0,
+			expected: "<........>",
+		},
+		{
+			name:     "five args finished",
+			template: `{{bar . "<" "=" ">" "." ">"}}`,
+			current:  100,
+			finished: true,
+			expected: "<========>",
+		},
+		{
+			name:     "explicit empty extras",
+			template: `{{bar . "<" "=" ">" "." ">" "" ""}}`,
+			current:  0,
+			expected: "<........>",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			bar := New64(100).SetTemplate(test.template).SetCurrent(test.current).SetWidth(10)
+			if test.finished {
+				bar.Finish()
+			}
+
+			result := bar.String()
+			if result != test.expected {
+				t.Errorf("explicit bar args must be used: %q; want %q", result, test.expected)
+			}
+		})
 	}
 }
 

--- a/v3/pb_test.go
+++ b/v3/pb_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -110,6 +111,8 @@ func TestAddTotal(t *testing.T) {
 }
 
 func TestPBTemplate(t *testing.T) {
+	defer setEnv(unicodeProgressBarEnv, "false")()
+
 	bar := new(ProgressBar)
 	result := bar.SetTotal(100).SetCurrent(50).SetWidth(40).String()
 	expected := "50 / 100 [------->________] 50.00% ? p/s"
@@ -145,6 +148,33 @@ func TestPBTemplate(t *testing.T) {
 	expected = "50 / 100"
 	if result != expected {
 		t.Errorf("Unexpected result: (actual/expected)\n%s\n%s", result, expected)
+	}
+}
+
+func TestUnicodeProgressBarEnvUsesUnicodeDefault(t *testing.T) {
+	defer setEnv(unicodeProgressBarEnv, "true")()
+
+	result := New(100).SetCurrent(0).SetWidth(60).String()
+	if !strings.Contains(result, "") {
+		t.Errorf("unicode default must use empty left border: %q", result)
+	}
+	if !strings.Contains(result, "") {
+		t.Errorf("unicode default must use empty right border: %q", result)
+	}
+	if strings.Contains(result, "") {
+		t.Errorf("unicode default must not include spinner: %q", result)
+	}
+}
+
+func TestUnicodeProgressBarEnvDoesNotOverrideExplicitTemplate(t *testing.T) {
+	defer setEnv(unicodeProgressBarEnv, "true")()
+
+	result := New(100).SetCurrent(0).SetWidth(60).SetTemplate(Default).String()
+	if !strings.Contains(result, "[") {
+		t.Errorf("explicit template must keep default left border: %q", result)
+	}
+	if strings.Contains(result, "") {
+		t.Errorf("explicit template must not use unicode default: %q", result)
 	}
 }
 
@@ -229,6 +259,19 @@ func TestPBFlags(t *testing.T) {
 	expected = "\r" + color.RedString("50 / 100") + "  "
 	if result != expected {
 		t.Errorf("Unexpected result: (actual/expected)\n'%s'\n'%s'", result, expected)
+	}
+}
+
+func setEnv(key, value string) func() {
+	old, ok := os.LookupEnv(key)
+	os.Setenv(key, value)
+
+	return func() {
+		if ok {
+			os.Setenv(key, old)
+			return
+		}
+		os.Unsetenv(key)
 	}
 }
 

--- a/v3/preset.go
+++ b/v3/preset.go
@@ -12,6 +12,4 @@ var (
 	// Simple - preset without speed and any timers. Only counters, bar and percents
 	// Example: 'Prefix 20/100 [-->______] 20% Suffix'
 	Simple ProgressBarTemplate = `{{with string . "prefix"}}{{.}} {{end}}{{counters . }} {{bar . }} {{percent . }}{{with string . "suffix"}} {{.}}{{end}}`
-
-	unicodeDefault ProgressBarTemplate = `{{with string . "prefix"}}{{.}} {{end}}{{counters . }} {{bar . "" "" "" "" "" "" ""}} {{percent . }} {{speed . }}{{with string . "suffix"}} {{.}}{{end}}`
 )

--- a/v3/preset.go
+++ b/v3/preset.go
@@ -12,4 +12,6 @@ var (
 	// Simple - preset without speed and any timers. Only counters, bar and percents
 	// Example: 'Prefix 20/100 [-->______] 20% Suffix'
 	Simple ProgressBarTemplate = `{{with string . "prefix"}}{{.}} {{end}}{{counters . }} {{bar . }} {{percent . }}{{with string . "suffix"}} {{.}}{{end}}`
+
+	unicodeDefault ProgressBarTemplate = `{{with string . "prefix"}}{{.}} {{end}}{{counters . }} {{bar . "" "" "" "" "" "" ""}} {{percent . }} {{speed . }}{{with string . "suffix"}} {{.}}{{end}}`
 )


### PR DESCRIPTION
This adds support for progress bar glyph sets that need distinct empty/filled border characters, such as the Unicode progress bar glyphs provided by [Fira Code](https://github.com/tonsky/FiraCode).

<img src="https://raw.githubusercontent.com/tonsky/FiraCode/727682c24c33fb0bbc7ab0ed9b7a8d0d9745a198/extras/progress.png" width="754">

<img src="https://raw.githubusercontent.com/tonsky/FiraCode/refs/heads/master/extras/progress.gif" width="560">

Changes:
- Extends the `bar` template element with optional 6th and 7th arguments:
    - 6th: empty-state left border
    - 7th: finished-state right border
- Keeps existing 5-argument `bar` templates fully backward compatible.
- Adds an opt-in `UNICODE_PROGRESS_BAR=true` gate (as suggested by FiraCode readme) for using the Unicode progress bar glyphs as the implicit default template.
- Documents the new template arguments and environment variable.

