### PR TITLE
Define terminalWidth on GOOS=wasip1 via the appengine/js stub

### DIFF
--- a/pb_appengine.go
+++ b/pb_appengine.go
@@ -1,11 +1,12 @@
-// +build appengine js
+// +build appengine js wasip1
 
 package pb
 
 import "errors"
 
 // terminalWidth returns width of the terminal, which is not supported
-// and should always failed on appengine classic which is a sandboxed PaaS.
+// and should always failed on appengine classic which is a sandboxed PaaS,
+// and on wasip1 which has no terminal-size API.
 func terminalWidth() (int, error) {
 	return 0, errors.New("Not supported")
 }


### PR DESCRIPTION
Hi, and thanks for maintaining pb!

Since Go 1.21 added `GOOS=wasip1` (WASI preview 1), building package `pb` for that platform fails, because none of the existing `terminalWidth` implementations is selected there:

```
pb.go:427:9: undefined: terminalWidth
pb.go:436:18: undefined: terminalWidth
```

`pb_x.go` is gated to the Unix-like platforms, `pb_win.go` to Windows, `pb_plan9.go` to Plan 9, and `pb_appengine.go` to `appengine`/`js`. This also breaks downstream users of the v1 line on wasip1 — for example `github.com/codesenberg/bombardier`, which depends on `pb` v1.

WASI preview 1 has no terminal-size API, so the appengine/js stub (`return 0, errors.New("Not supported")`) is the correct behavior there as well: callers like `GetWidth` already fall back to the default width when `terminalWidth` returns an error. This PR just adds `wasip1` to that stub's build tags, matching the file's existing tag style.

Verified with Go 1.21+:
- `GOOS=wasip1 GOARCH=wasm go build .` now succeeds, selecting `pb_appengine.go`
- `go list -f '{{.GoFiles}}'` output on linux/darwin/windows is unchanged

Happy to adjust (e.g. add a `//go:build` line as well) if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)